### PR TITLE
Add versioning and fix naming conflict error

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "embd"]
-	path = embd
-	url = https://github.com/kidoman/embd

--- a/ahrs/ahrs_kalman.go
+++ b/ahrs/ahrs_kalman.go
@@ -3,9 +3,10 @@
 package ahrs
 
 import (
-	"github.com/skelterjohn/go.matrix"
 	"log"
 	"math"
+
+	"github.com/skelterjohn/go.matrix"
 )
 
 type KalmanState struct {
@@ -40,33 +41,33 @@ func (s *KalmanState) init(m *Measurement) {
 	// Diagonal matrix of initial state uncertainties, will be squared into covariance below
 	// Specifics here aren't too important--it will change very quickly
 	s.M = matrix.Diagonal([]float64{
-		50, 5, 5,                   // U*3
-		0.4, 0.2, 0.5,              // Z*3
-		0.5, 0.5, 0.5, 0.5,         // E*4
-		2, 2, 2,                    // H*3
-		65, 65, 65,                 // N*3
-		10, 10, 2,                  // V*3
-		0.02, 0.02, 0.02,           // C*3
+		50, 5, 5, // U*3
+		0.4, 0.2, 0.5, // Z*3
+		0.5, 0.5, 0.5, 0.5, // E*4
+		2, 2, 2, // H*3
+		65, 65, 65, // N*3
+		10, 10, 2, // V*3
+		0.02, 0.02, 0.02, // C*3
 		0.002, 0.002, 0.002, 0.002, // F*4
-		0.1, 0.1, 0.1,              // D*4
-		10, 10, 10,                 // L*4
+		0.1, 0.1, 0.1, // D*4
+		10, 10, 10, // L*4
 	})
 	s.M = matrix.Product(s.M, s.M)
 
 	// Diagonal matrix of state process uncertainties per s, will be squared into covariance below
 	// Tuning these is more important
-	tt := math.Sqrt(60.0*60.0) // One-hour time constant for drift of biases V, C, F, D, L
+	tt := math.Sqrt(60.0 * 60.0) // One-hour time constant for drift of biases V, C, F, D, L
 	s.N = matrix.Diagonal([]float64{
-		1, 0.1, 0.1,                                // U*3
-		0.2, 0.1, 0.2,                              // Z*3
-		0.02, 0.02, 0.02, 0.02,                     // E*4
-		1, 1, 1,                                    // H*3
-		100, 100, 100,                              // N*3
-		5/tt, 5/tt, 5/tt,                           // V*3
-		0.01/tt, 0.01/tt, 0.01/tt,                  // C*3
-		0.0001/tt, 0.0001/tt, 0.0001/tt, 0.0001/tt, // F*4
-		0.1/tt, 0.1/tt, 0.1/tt,                     // D*3
-		0.1/tt, 0.1/tt, 0.1/tt,                     // L*3
+		1, 0.1, 0.1, // U*3
+		0.2, 0.1, 0.2, // Z*3
+		0.02, 0.02, 0.02, 0.02, // E*4
+		1, 1, 1, // H*3
+		100, 100, 100, // N*3
+		5 / tt, 5 / tt, 5 / tt, // V*3
+		0.01 / tt, 0.01 / tt, 0.01 / tt, // C*3
+		0.0001 / tt, 0.0001 / tt, 0.0001 / tt, 0.0001 / tt, // F*4
+		0.1 / tt, 0.1 / tt, 0.1 / tt, // D*3
+		0.1 / tt, 0.1 / tt, 0.1 / tt, // L*3
 	})
 	s.N = matrix.Product(s.N, s.N)
 
@@ -83,7 +84,7 @@ func (s *KalmanState) init(m *Measurement) {
 	// Best guess at initial heading is initial track
 	if m.WValid && s.U1 > 5 {
 		// Simplified half-angle formulae
-		s.E0, s.E3 = math.Sqrt((s.U1 + m.W1) / (2 * s.U1)), math.Sqrt((s.U1 - m.W1) / (2 * s.U1))
+		s.E0, s.E3 = math.Sqrt((s.U1+m.W1)/(2*s.U1)), math.Sqrt((s.U1-m.W1)/(2*s.U1))
 		if m.W2 < 0 {
 			s.E3 *= -1
 		}
@@ -130,7 +131,6 @@ func (s *KalmanState) Valid() (ok bool) {
 		ok = false
 	}
 
-
 	if math.Abs(s.U1) > 300 || math.Abs(s.U2) > 20 || math.Abs(s.U3) > 20 ||
 		math.Abs(s.V1) > 40 || math.Abs(s.V2) > 40 || math.Abs(s.V3) > 40 {
 		log.Println("Speeds too high")
@@ -153,14 +153,14 @@ func (s *KalmanState) Predict(t float64) {
 	f := s.calcJacobianState(t)
 	dt := t - s.T
 
-	s.U1 += dt*s.Z1*G
-	s.U2 += dt*s.Z2*G
-	s.U3 += dt*s.Z3*G
+	s.U1 += dt * s.Z1 * G
+	s.U2 += dt * s.Z2 * G
+	s.U3 += dt * s.Z3 * G
 
-	s.E0 += 0.5*dt*(-s.H1*s.E1 - s.H2*s.E2 - s.H3*s.E3)*Deg
-	s.E1 += 0.5*dt*(+s.H1*s.E0 + s.H2*s.E3 - s.H3*s.E2)*Deg
-	s.E2 += 0.5*dt*(-s.H1*s.E3 + s.H2*s.E0 + s.H3*s.E1)*Deg
-	s.E3 += 0.5*dt*(+s.H1*s.E2 - s.H2*s.E1 + s.H3*s.E0)*Deg
+	s.E0 += 0.5 * dt * (-s.H1*s.E1 - s.H2*s.E2 - s.H3*s.E3) * Deg
+	s.E1 += 0.5 * dt * (+s.H1*s.E0 + s.H2*s.E3 - s.H3*s.E2) * Deg
+	s.E2 += 0.5 * dt * (-s.H1*s.E3 + s.H2*s.E0 + s.H3*s.E1) * Deg
+	s.E3 += 0.5 * dt * (+s.H1*s.E2 - s.H2*s.E1 + s.H3*s.E0) * Deg
 	s.normalize()
 
 	// All other state vectors are unchanged
@@ -183,21 +183,21 @@ func (s *KalmanState) Update(m *Measurement) {
 	}
 
 	y := matrix.Zeros(15, 1)
-	y.Set( 0, 0, m.U1 - z.U1)
-	y.Set( 1, 0, m.U2 - z.U2)
-	y.Set( 2, 0, m.U3 - z.U3)
-	y.Set( 3, 0, m.W1 - z.W1)
-	y.Set( 4, 0, m.W2 - z.W2)
-	y.Set( 5, 0, m.W3 - z.W3)
-	y.Set( 6, 0, m.A1 - z.A1)
-	y.Set( 7, 0, m.A2 - z.A2)
-	y.Set( 8, 0, m.A3 - z.A3)
-	y.Set( 9, 0, m.B1 - z.B1)
-	y.Set(10, 0, m.B2 - z.B2)
-	y.Set(11, 0, m.B3 - z.B3)
-	y.Set(12, 0, m.M1 - z.M1)
-	y.Set(13, 0, m.M2 - z.M2)
-	y.Set(14, 0, m.M3 - z.M3)
+	y.Set(0, 0, m.U1-z.U1)
+	y.Set(1, 0, m.U2-z.U2)
+	y.Set(2, 0, m.U3-z.U3)
+	y.Set(3, 0, m.W1-z.W1)
+	y.Set(4, 0, m.W2-z.W2)
+	y.Set(5, 0, m.W3-z.W3)
+	y.Set(6, 0, m.A1-z.A1)
+	y.Set(7, 0, m.A2-z.A2)
+	y.Set(8, 0, m.A3-z.A3)
+	y.Set(9, 0, m.B1-z.B1)
+	y.Set(10, 0, m.B2-z.B2)
+	y.Set(11, 0, m.B3-z.B3)
+	y.Set(12, 0, m.M1-z.M1)
+	y.Set(13, 0, m.M2-z.M2)
+	y.Set(14, 0, m.M3-z.M3)
 
 	h := s.calcJacobianMeasurement()
 
@@ -245,16 +245,16 @@ func (s *KalmanState) Update(m *Measurement) {
 		_, _, v = m.Accums[11](m.B3)
 		m.M.Set(11, 11, v)
 	} else {
-		y.Set( 6, 0, 0)
-		y.Set( 7, 0, 0)
-		y.Set( 8, 0, 0)
-		y.Set( 9, 0, 0)
+		y.Set(6, 0, 0)
+		y.Set(7, 0, 0)
+		y.Set(8, 0, 0)
+		y.Set(9, 0, 0)
 		y.Set(10, 0, 0)
 		y.Set(11, 0, 0)
-		m.M.Set( 6,  6, Big)
-		m.M.Set( 7,  7, Big)
-		m.M.Set( 8,  8, Big)
-		m.M.Set( 9,  9, Big)
+		m.M.Set(6, 6, Big)
+		m.M.Set(7, 7, Big)
+		m.M.Set(8, 8, Big)
+		m.M.Set(9, 9, Big)
 		m.M.Set(10, 10, Big)
 		m.M.Set(11, 11, Big)
 	}
@@ -284,16 +284,16 @@ func (s *KalmanState) Update(m *Measurement) {
 	}
 	kk := matrix.Product(s.M, matrix.Product(h.Transpose(), m2))
 	su := matrix.Product(kk, y)
-	s.U1 += su.Get( 0, 0)
-	s.U2 += su.Get( 1, 0)
-	s.U3 += su.Get( 2, 0)
-	s.Z1 += su.Get( 3, 0)
-	s.Z2 += su.Get( 4, 0)
-	s.Z3 += su.Get( 5, 0)
-	s.E0 += su.Get( 6, 0)
-	s.E1 += su.Get( 7, 0)
-	s.E2 += su.Get( 8, 0)
-	s.E3 += su.Get( 9, 0)
+	s.U1 += su.Get(0, 0)
+	s.U2 += su.Get(1, 0)
+	s.U3 += su.Get(2, 0)
+	s.Z1 += su.Get(3, 0)
+	s.Z2 += su.Get(4, 0)
+	s.Z3 += su.Get(5, 0)
+	s.E0 += su.Get(6, 0)
+	s.E1 += su.Get(7, 0)
+	s.E2 += su.Get(8, 0)
+	s.E3 += su.Get(9, 0)
 	s.H1 += su.Get(10, 0)
 	s.H2 += su.Get(11, 0)
 	s.H3 += su.Get(12, 0)
@@ -339,9 +339,9 @@ func (s *KalmanState) PredictMeasurement() (m *Measurement) {
 	h1 := s.H1*s.e11 + s.H2*s.e21 + s.H3*s.e31
 	h2 := s.H1*s.e12 + s.H2*s.e22 + s.H3*s.e32
 	h3 := s.H1*s.e13 + s.H2*s.e23 + s.H3*s.e33
-	a1 := -s.Z1 + (h3*s.U2 - h2*s.U3)*Deg/G - s.e31
-	a2 := -s.Z2 + (h1*s.U3 - h3*s.U1)*Deg/G - s.e32
-	a3 := -s.Z3 + (h2*s.U1 - h1*s.U2)*Deg/G - s.e33
+	a1 := -s.Z1 + (h3*s.U2-h2*s.U3)*Deg/G - s.e31
+	a2 := -s.Z2 + (h1*s.U3-h3*s.U1)*Deg/G - s.e32
+	a3 := -s.Z3 + (h2*s.U1-h1*s.U2)*Deg/G - s.e33
 
 	m.A1 = s.f11*a1 + s.f12*a2 + s.f13*a3 + s.C1
 	m.A2 = s.f21*a1 + s.f22*a2 + s.f23*a3 + s.C2
@@ -352,9 +352,9 @@ func (s *KalmanState) PredictMeasurement() (m *Measurement) {
 	m.B3 = s.f31*h1 + s.f32*h2 + s.f33*h3 + s.D3
 
 	m.MValid = true
-	m1 :=  s.N1*s.e11 + s.N2*s.e21 + s.N3*s.e31 + s.L1
-	m2 :=  s.N1*s.e12 + s.N2*s.e22 + s.N3*s.e32 + s.L2
-	m3 :=  s.N1*s.e13 + s.N2*s.e23 + s.N3*s.e33 + s.L3
+	m1 := s.N1*s.e11 + s.N2*s.e21 + s.N3*s.e31 + s.L1
+	m2 := s.N1*s.e12 + s.N2*s.e22 + s.N3*s.e32 + s.L2
+	m3 := s.N1*s.e13 + s.N2*s.e23 + s.N3*s.e33 + s.L3
 	m.M1 = s.f11*m1 + s.f12*m2 + s.f13*m3
 	m.M2 = s.f21*m1 + s.f22*m2 + s.f23*m3
 	m.M3 = s.f31*m1 + s.f32*m2 + s.f33*m3
@@ -365,50 +365,50 @@ func (s *KalmanState) PredictMeasurement() (m *Measurement) {
 }
 
 func (s *KalmanState) calcJacobianState(t float64) (jac *matrix.DenseMatrix) {
-	dt := t-s.T
+	dt := t - s.T
 
 	jac = matrix.Eye(32)
 	// U*3, Z*3, E*4, H*3, N*3,
 	// V*3, C*3, F*4, D*3, L*3
 
 	//s.U1 += dt*s.Z1*G
-	jac.Set(0, 3, dt*G)                // U1/Z1
+	jac.Set(0, 3, dt*G) // U1/Z1
 	//s.U2 += dt*s.Z2*G
-	jac.Set(1, 4, dt*G)                // U2/Z2
+	jac.Set(1, 4, dt*G) // U2/Z2
 	//s.U3 += dt*s.Z3*G
-	jac.Set(2, 5, dt*G)                // U3/Z3
+	jac.Set(2, 5, dt*G) // U3/Z3
 
 	//s.E0 += 0.5*dt*(-s.H1*s.E1 - s.H2*s.E2 - s.H3*s.E3)*Deg
-	jac.Set(6,  7, -0.5*dt*s.H1*Deg)  // E0/E1
-	jac.Set(6,  8, -0.5*dt*s.H2*Deg)  // E0/E2
-	jac.Set(6,  9, -0.5*dt*s.H3*Deg)  // E0/E3
-	jac.Set(6, 10, -0.5*dt*s.E1*Deg)  // E0/H1
-	jac.Set(6, 11, -0.5*dt*s.E2*Deg)  // E0/H2
-	jac.Set(6, 12, -0.5*dt*s.E3*Deg)  // E0/H3
+	jac.Set(6, 7, -0.5*dt*s.H1*Deg)  // E0/E1
+	jac.Set(6, 8, -0.5*dt*s.H2*Deg)  // E0/E2
+	jac.Set(6, 9, -0.5*dt*s.H3*Deg)  // E0/E3
+	jac.Set(6, 10, -0.5*dt*s.E1*Deg) // E0/H1
+	jac.Set(6, 11, -0.5*dt*s.E2*Deg) // E0/H2
+	jac.Set(6, 12, -0.5*dt*s.E3*Deg) // E0/H3
 
 	//s.E1 += 0.5*dt*(+s.H1*s.E0 + s.H2*s.E3 - s.H3*s.E2)*Deg
-	jac.Set(7,  6, +0.5*dt*s.H1*Deg)  // E1/E0
-	jac.Set(7,  8, -0.5*dt*s.H3*Deg)  // E1/E2
-	jac.Set(7,  9, +0.5*dt*s.H2*Deg)  // E1/E3
-	jac.Set(7, 10, +0.5*dt*s.E0*Deg)  // E1/H1
-	jac.Set(7, 11, +0.5*dt*s.E3*Deg)  // E1/H2
-	jac.Set(7, 12, -0.5*dt*s.E2*Deg)  // E1/H3
+	jac.Set(7, 6, +0.5*dt*s.H1*Deg)  // E1/E0
+	jac.Set(7, 8, -0.5*dt*s.H3*Deg)  // E1/E2
+	jac.Set(7, 9, +0.5*dt*s.H2*Deg)  // E1/E3
+	jac.Set(7, 10, +0.5*dt*s.E0*Deg) // E1/H1
+	jac.Set(7, 11, +0.5*dt*s.E3*Deg) // E1/H2
+	jac.Set(7, 12, -0.5*dt*s.E2*Deg) // E1/H3
 
 	//s.E2 += 0.5*dt*(-s.H1*s.E3 + s.H2*s.E0 + s.H3*s.E1)*Deg
-	jac.Set(8,  6, +0.5*dt*s.H2*Deg)  // E2/E0
-	jac.Set(8,  7, +0.5*dt*s.H3*Deg)  // E2/E1
-	jac.Set(8,  9, -0.5*dt*s.H1*Deg)  // E2/E3
-	jac.Set(8, 10, -0.5*dt*s.E3*Deg)  // E2/H1
-	jac.Set(8, 11, +0.5*dt*s.E0*Deg)  // E2/H2
-	jac.Set(8, 12, +0.5*dt*s.E1*Deg)  // E2/H3
+	jac.Set(8, 6, +0.5*dt*s.H2*Deg)  // E2/E0
+	jac.Set(8, 7, +0.5*dt*s.H3*Deg)  // E2/E1
+	jac.Set(8, 9, -0.5*dt*s.H1*Deg)  // E2/E3
+	jac.Set(8, 10, -0.5*dt*s.E3*Deg) // E2/H1
+	jac.Set(8, 11, +0.5*dt*s.E0*Deg) // E2/H2
+	jac.Set(8, 12, +0.5*dt*s.E1*Deg) // E2/H3
 
 	//s.E3 += 0.5*dt*(+s.H1*s.E2 - s.H2*s.E1 + s.H3*s.E0)*Deg
-	jac.Set(9,  6, +0.5*dt*s.H3*Deg)  // E3/E0
-	jac.Set(9,  7, -0.5*dt*s.H2*Deg)  // E3/E1
-	jac.Set(9,  8, +0.5*dt*s.H1*Deg)  // E3/E2
-	jac.Set(9, 10, +0.5*dt*s.E2*Deg)  // E3/H1
-	jac.Set(9, 11, -0.5*dt*s.E1*Deg)  // E3/H2
-	jac.Set(9, 12, +0.5*dt*s.E0*Deg)  // E3/H3
+	jac.Set(9, 6, +0.5*dt*s.H3*Deg)  // E3/E0
+	jac.Set(9, 7, -0.5*dt*s.H2*Deg)  // E3/E1
+	jac.Set(9, 8, +0.5*dt*s.H1*Deg)  // E3/E2
+	jac.Set(9, 10, +0.5*dt*s.E2*Deg) // E3/H1
+	jac.Set(9, 11, -0.5*dt*s.E1*Deg) // E3/H2
+	jac.Set(9, 12, +0.5*dt*s.E0*Deg) // E3/H3
 
 	return
 }
@@ -421,396 +421,396 @@ func (s *KalmanState) calcJacobianMeasurement() (jac *matrix.DenseMatrix) {
 	// U*3, W*3, A*3, B*3, M*3
 
 	//m.U1 = s.U1
-	jac.Set(0, 0, 1)                                              // U1/U1
+	jac.Set(0, 0, 1) // U1/U1
 	//m.U2 = s.U2
-	jac.Set(1, 1, 1)                                              // U2/U2
+	jac.Set(1, 1, 1) // U2/U2
 	//m.U3 = s.U3
-	jac.Set(2, 2, 1)                                              // U3/U3
+	jac.Set(2, 2, 1) // U3/U3
 
 	w1 := s.e11*s.U1 + s.e12*s.U2 + s.e13*s.U3
 	//s.e11 = 2*(+s.E0 * s.E0 + s.E1 * s.E1 - 0.5)
 	//s.e12 = 2*(-s.E0 * s.E3 + s.E1 * s.E2)
 	//s.e13 = 2*(+s.E0 * s.E2 + s.E1 * s.E3)
-	jac.Set(3, 0, s.e11)                                          // W1/U1
-	jac.Set(3, 1, s.e12)                                          // W1/U2
-	jac.Set(3, 2, s.e13)                                          // W1/U3
-	jac.Set(3, 6,                                                 // W1/E0
-		2*(+s.E0*s.U1 - s.E3*s.U2 + s.E2*s.U3) -
-		2*w1*s.E0)
-	jac.Set(3, 7,                                                 // W1/E1
-		2*(+s.E1*s.U1 + s.E2*s.U2 + s.E3*s.U3) -
-		2*w1*s.E1)
-	jac.Set(3, 8,                                                 // W1/E2
-		2*(-s.E2*s.U1 + s.E1*s.U2 + s.E0*s.U3) -
-		2*w1*s.E2)
-	jac.Set(3, 9,                                                 // W1/E3
-		2*(-s.E3*s.U1 - s.E0*s.U2 + s.E1*s.U3) -
-		2*w1*s.E3)
-	jac.Set(3, 16, 1)                                             // W1/V1
+	jac.Set(3, 0, s.e11) // W1/U1
+	jac.Set(3, 1, s.e12) // W1/U2
+	jac.Set(3, 2, s.e13) // W1/U3
+	jac.Set(3, 6,        // W1/E0
+		2*(+s.E0*s.U1-s.E3*s.U2+s.E2*s.U3)-
+			2*w1*s.E0)
+	jac.Set(3, 7, // W1/E1
+		2*(+s.E1*s.U1+s.E2*s.U2+s.E3*s.U3)-
+			2*w1*s.E1)
+	jac.Set(3, 8, // W1/E2
+		2*(-s.E2*s.U1+s.E1*s.U2+s.E0*s.U3)-
+			2*w1*s.E2)
+	jac.Set(3, 9, // W1/E3
+		2*(-s.E3*s.U1-s.E0*s.U2+s.E1*s.U3)-
+			2*w1*s.E3)
+	jac.Set(3, 16, 1) // W1/V1
 
 	w2 := s.e21*s.U1 + s.e22*s.U2 + s.e23*s.U3
 	//s.e21 = 2*(+s.E0 * s.E3 + s.E2 * s.E1)
 	//s.e22 = 2*(+s.E0 * s.E0 + s.E2 * s.E2 - 0.5)
 	//s.e23 = 2*(-s.E0 * s.E1 + s.E2 * s.E3)
-	jac.Set(4, 0, s.e21)                                          // W2/U1
-	jac.Set(4, 1, s.e22)                                          // W2/U2
-	jac.Set(4, 2, s.e23)                                          // W2/U3
-	jac.Set(4, 6,                                                 // W2/E0
-		2*(+s.E3*s.U1 + s.E0*s.U2 - s.E1*s.U3) -
-		2*w2*s.E0)
-	jac.Set(4, 7,                                                 // W2/E1
-		2*(+s.E2*s.U1 - s.E1*s.U2 - s.E0*s.U3) -
-		2*w2*s.E1)
-	jac.Set(4, 8,                                                 // W2/E2
-		2*(+s.E1*s.U1 + s.E2*s.U2 + s.E3*s.U3) -
-		2*w2*s.E2)
-	jac.Set(4, 9,                                                 // W2/E3
-		2*(+s.E0*s.U1 - s.E3*s.U2 + s.E2*s.U3) -
-		2*w2*s.E3)
-	jac.Set(4, 17, 1)                                             // W2/V2
+	jac.Set(4, 0, s.e21) // W2/U1
+	jac.Set(4, 1, s.e22) // W2/U2
+	jac.Set(4, 2, s.e23) // W2/U3
+	jac.Set(4, 6,        // W2/E0
+		2*(+s.E3*s.U1+s.E0*s.U2-s.E1*s.U3)-
+			2*w2*s.E0)
+	jac.Set(4, 7, // W2/E1
+		2*(+s.E2*s.U1-s.E1*s.U2-s.E0*s.U3)-
+			2*w2*s.E1)
+	jac.Set(4, 8, // W2/E2
+		2*(+s.E1*s.U1+s.E2*s.U2+s.E3*s.U3)-
+			2*w2*s.E2)
+	jac.Set(4, 9, // W2/E3
+		2*(+s.E0*s.U1-s.E3*s.U2+s.E2*s.U3)-
+			2*w2*s.E3)
+	jac.Set(4, 17, 1) // W2/V2
 
 	w3 := s.e31*s.U1 + s.e32*s.U2 + s.e33*s.U3
 	//s.e31 = 2*(-s.E0 * s.E2 + s.E3 * s.E1)
 	//s.e32 = 2*(+s.E0 * s.E1 + s.E3 * s.E2)
 	//s.e33 = 2*(+s.E0 * s.E0 + s.E3 * s.E3 - 0.5)
-	jac.Set(5, 0, s.e31)                                          // W3/U1
-	jac.Set(5, 1, s.e32)                                          // W3/U2
-	jac.Set(5, 2, s.e33)                                          // W3/U3
-	jac.Set(5, 6,                                                 // W3/E0
-		2*(-s.E2*s.U1 + s.E1*s.U2 + s.E0*s.U3) -
-		2*w3*s.E0)
-	jac.Set(5, 7,                                                 // W3/E1
-		2*(+s.E3*s.U1 + s.E0*s.U2 - s.E1*s.U3) -
-		2*w3*s.E1)
-	jac.Set(5, 8,                                                 // W3/E2
-		2*(-s.E0*s.U1 + s.E3*s.U2 - s.E2*s.U3) -
-		2*w3*s.E2)
-	jac.Set(5, 9,                                                 // W3/E3
-		2*(+s.E1*s.U1 + s.E2*s.U2 + s.E3*s.U3) -
-		2*w3*s.E3)
-	jac.Set(5, 18, 1)                                             // W3/V3
+	jac.Set(5, 0, s.e31) // W3/U1
+	jac.Set(5, 1, s.e32) // W3/U2
+	jac.Set(5, 2, s.e33) // W3/U3
+	jac.Set(5, 6,        // W3/E0
+		2*(-s.E2*s.U1+s.E1*s.U2+s.E0*s.U3)-
+			2*w3*s.E0)
+	jac.Set(5, 7, // W3/E1
+		2*(+s.E3*s.U1+s.E0*s.U2-s.E1*s.U3)-
+			2*w3*s.E1)
+	jac.Set(5, 8, // W3/E2
+		2*(-s.E0*s.U1+s.E3*s.U2-s.E2*s.U3)-
+			2*w3*s.E2)
+	jac.Set(5, 9, // W3/E3
+		2*(+s.E1*s.U1+s.E2*s.U2+s.E3*s.U3)-
+			2*w3*s.E3)
+	jac.Set(5, 18, 1) // W3/V3
 
 	h1 := s.H1*s.e11 + s.H2*s.e21 + s.H3*s.e31
 	h2 := s.H1*s.e12 + s.H2*s.e22 + s.H3*s.e32
 	h3 := s.H1*s.e13 + s.H2*s.e23 + s.H3*s.e33
-	a1 := -s.Z1 + (h3*s.U2 - h2*s.U3)*Deg/G - s.e31
-	a2 := -s.Z2 + (h1*s.U3 - h3*s.U1)*Deg/G - s.e32
-	a3 := -s.Z3 + (h2*s.U1 - h1*s.U2)*Deg/G - s.e33
+	a1 := -s.Z1 + (h3*s.U2-h2*s.U3)*Deg/G - s.e31
+	a2 := -s.Z2 + (h1*s.U3-h3*s.U1)*Deg/G - s.e32
+	a3 := -s.Z3 + (h2*s.U1-h1*s.U2)*Deg/G - s.e33
 
 	ae1 := s.f11*(a1+s.Z1) + s.f12*(a2+s.Z2) + s.f13*(a3+s.Z3)
 	af1 := s.f11*a1 + s.f12*a2 + s.f13*a3
-	jac.Set(6, 0, (s.f13*h2 - s.f12*h3)*Deg/G)                    // A1/U1
-	jac.Set(6, 1, (s.f11*h3 - s.f13*h1)*Deg/G)                    // A1/U2
-	jac.Set(6, 2, (s.f12*h1 - s.f11*h2)*Deg/G)                    // A1/U3
-	jac.Set(6, 3, -s.f11)                                         // A1/Z1
-	jac.Set(6, 4, -s.f12)                                         // A1/Z2
-	jac.Set(6, 5, -s.f13)                                         // A1/Z3
-	jac.Set(6, 6, 2*Deg/G*(                                       // A1/E0
-		s.f11*(s.H1*( s.E2*s.U2 + s.E3*s.U3) + s.H2*(-s.E1*s.U2 - s.E0*s.U3) + s.H3*( s.E0*s.U2 - s.E1*s.U3)) +
-		s.f12*(s.H1*( s.E0*s.U3 - s.E2*s.U1) + s.H2*( s.E3*s.U3 + s.E1*s.U1) + s.H3*(-s.E2*s.U3 - s.E0*s.U1)) +
-		s.f13*(s.H1*(-s.E3*s.U1 - s.E0*s.U2) + s.H2*( s.E0*s.U1 - s.E3*s.U2) + s.H3*( s.E1*s.U1 + s.E2*s.U2)) ) -
-		2* ae1 *s.E0 -
-		2*(s.f11*(-s.E2) + s.f12*( s.E1) + s.f13*( s.E0)) )
-	jac.Set(6, 7, 2*Deg/G*(                                       // A1/E1
-		s.f11*(s.H1*( s.E3*s.U2 - s.E2*s.U3) + s.H2*(-s.E0*s.U2 + s.E1*s.U3) + s.H3*(-s.E1*s.U2 - s.E0*s.U3)) +
-		s.f12*(s.H1*( s.E1*s.U3 - s.E3*s.U1) + s.H2*( s.E2*s.U3 + s.E0*s.U1) + s.H3*( s.E3*s.U3 + s.E1*s.U1)) +
-		s.f13*(s.H1*( s.E2*s.U1 - s.E1*s.U2) + s.H2*(-s.E1*s.U1 - s.E2*s.U2) + s.H3*( s.E0*s.U1 - s.E3*s.U2)) ) -
-		2* ae1 *s.E1 -
-		2*(s.f11*( s.E3) + s.f12*( s.E0) + s.f13*(-s.E1)) )
-	jac.Set(6, 8, 2*Deg/G*(                                       // A1/E2
-		s.f11*(s.H1*( s.E0*s.U2 - s.E1*s.U3) + s.H2*( s.E3*s.U2 - s.E2*s.U3) + s.H3*(-s.E2*s.U2 - s.E3*s.U3)) +
-		s.f12*(s.H1*(-s.E2*s.U3 - s.E0*s.U1) + s.H2*( s.E1*s.U3 - s.E3*s.U1) + s.H3*(-s.E0*s.U3 + s.E2*s.U1)) +
-		s.f13*(s.H1*( s.E1*s.U1 + s.E2*s.U2) + s.H2*( s.E2*s.U1 - s.E1*s.U2) + s.H3*( s.E3*s.U1 + s.E0*s.U2)) ) -
-		2* ae1 *s.E2 -
-		2*(s.f11*(-s.E0) + s.f12*( s.E3) + s.f13*(-s.E2)) )
-	jac.Set(6, 9, 2*Deg/G*(                                       // A1/E3
-		s.f11*(s.H1*( s.E1*s.U2 + s.E0*s.U3) + s.H2*( s.E2*s.U2 + s.E3*s.U3) + s.H3*( s.E3*s.U2 - s.E2*s.U3)) +
-		s.f12*(s.H1*(-s.E3*s.U3 - s.E1*s.U1) + s.H2*( s.E0*s.U3 - s.E2*s.U1) + s.H3*( s.E1*s.U3 - s.E3*s.U1)) +
-		s.f13*(s.H1*(-s.E0*s.U1 + s.E3*s.U2) + s.H2*(-s.E3*s.U1 - s.E0*s.U2) + s.H3*( s.E2*s.U1 - s.E1*s.U2)) ) -
-		2* ae1 *s.E3 -
-		2*(s.f11*( s.E1) + s.f12*( s.E2) + s.f13*( s.E3)) )
-	jac.Set(6, 10, Deg/G*(                                      // A1/H1
-		s.f11*(s.U2*s.e13 - s.U3*s.e12) +
-		s.f12*(s.U3*s.e11 - s.U1*s.e13) +
-		s.f13*(s.U1*s.e12 - s.U2*s.e11) ))
-	jac.Set(6, 11, Deg/G*(                                      // A1/H2
-		s.f11*(s.U2*s.e23 - s.U3*s.e22) +
-		s.f12*(s.U3*s.e21 - s.U1*s.e23) +
-		s.f13*(s.U1*s.e22 - s.U2*s.e21) ))
-	jac.Set(6, 12, Deg/G*(                                      // A1/H3
-		s.f11*(s.U2*s.e33 - s.U3*s.e32) +
-		s.f12*(s.U3*s.e31 - s.U1*s.e33) +
-		s.f13*(s.U1*s.e32 - s.U2*s.e31) ))
-	jac.Set(6, 19, 1)                                             // A1/C1
-	jac.Set(6, 22,                                                // A1/F0
-		2*(+s.F0*a1 - s.F3*a2 + s.F2*a3) -
-		2*af1*s.F0)
-	jac.Set(6, 23,                                                // A1/F1
-		2*(+s.F1*a1 + s.F2*a2 + s.F3*a3) -
-		2*af1*s.F1)
-	jac.Set(6, 24,                                                // A1/F2
-		2*(-s.F2*a1 + s.F1*a2 + s.F0*a3) -
-		2*af1*s.F2)
-	jac.Set(6, 25,                                                // A1/F3
-		2*(-s.F3*a1 - s.F0*a2 + s.F1*a3) -
-		2*af1*s.F3)
+	jac.Set(6, 0, (s.f13*h2-s.f12*h3)*Deg/G) // A1/U1
+	jac.Set(6, 1, (s.f11*h3-s.f13*h1)*Deg/G) // A1/U2
+	jac.Set(6, 2, (s.f12*h1-s.f11*h2)*Deg/G) // A1/U3
+	jac.Set(6, 3, -s.f11)                    // A1/Z1
+	jac.Set(6, 4, -s.f12)                    // A1/Z2
+	jac.Set(6, 5, -s.f13)                    // A1/Z3
+	jac.Set(6, 6, 2*Deg/G*(                  // A1/E0
+	s.f11*(s.H1*(s.E2*s.U2+s.E3*s.U3)+s.H2*(-s.E1*s.U2-s.E0*s.U3)+s.H3*(s.E0*s.U2-s.E1*s.U3))+
+		s.f12*(s.H1*(s.E0*s.U3-s.E2*s.U1)+s.H2*(s.E3*s.U3+s.E1*s.U1)+s.H3*(-s.E2*s.U3-s.E0*s.U1))+
+		s.f13*(s.H1*(-s.E3*s.U1-s.E0*s.U2)+s.H2*(s.E0*s.U1-s.E3*s.U2)+s.H3*(s.E1*s.U1+s.E2*s.U2)))-
+		2*ae1*s.E0-
+		2*(s.f11*(-s.E2)+s.f12*(s.E1)+s.f13*(s.E0)))
+	jac.Set(6, 7, 2*Deg/G*( // A1/E1
+	s.f11*(s.H1*(s.E3*s.U2-s.E2*s.U3)+s.H2*(-s.E0*s.U2+s.E1*s.U3)+s.H3*(-s.E1*s.U2-s.E0*s.U3))+
+		s.f12*(s.H1*(s.E1*s.U3-s.E3*s.U1)+s.H2*(s.E2*s.U3+s.E0*s.U1)+s.H3*(s.E3*s.U3+s.E1*s.U1))+
+		s.f13*(s.H1*(s.E2*s.U1-s.E1*s.U2)+s.H2*(-s.E1*s.U1-s.E2*s.U2)+s.H3*(s.E0*s.U1-s.E3*s.U2)))-
+		2*ae1*s.E1-
+		2*(s.f11*(s.E3)+s.f12*(s.E0)+s.f13*(-s.E1)))
+	jac.Set(6, 8, 2*Deg/G*( // A1/E2
+	s.f11*(s.H1*(s.E0*s.U2-s.E1*s.U3)+s.H2*(s.E3*s.U2-s.E2*s.U3)+s.H3*(-s.E2*s.U2-s.E3*s.U3))+
+		s.f12*(s.H1*(-s.E2*s.U3-s.E0*s.U1)+s.H2*(s.E1*s.U3-s.E3*s.U1)+s.H3*(-s.E0*s.U3+s.E2*s.U1))+
+		s.f13*(s.H1*(s.E1*s.U1+s.E2*s.U2)+s.H2*(s.E2*s.U1-s.E1*s.U2)+s.H3*(s.E3*s.U1+s.E0*s.U2)))-
+		2*ae1*s.E2-
+		2*(s.f11*(-s.E0)+s.f12*(s.E3)+s.f13*(-s.E2)))
+	jac.Set(6, 9, 2*Deg/G*( // A1/E3
+	s.f11*(s.H1*(s.E1*s.U2+s.E0*s.U3)+s.H2*(s.E2*s.U2+s.E3*s.U3)+s.H3*(s.E3*s.U2-s.E2*s.U3))+
+		s.f12*(s.H1*(-s.E3*s.U3-s.E1*s.U1)+s.H2*(s.E0*s.U3-s.E2*s.U1)+s.H3*(s.E1*s.U3-s.E3*s.U1))+
+		s.f13*(s.H1*(-s.E0*s.U1+s.E3*s.U2)+s.H2*(-s.E3*s.U1-s.E0*s.U2)+s.H3*(s.E2*s.U1-s.E1*s.U2)))-
+		2*ae1*s.E3-
+		2*(s.f11*(s.E1)+s.f12*(s.E2)+s.f13*(s.E3)))
+	jac.Set(6, 10, Deg/G*( // A1/H1
+	s.f11*(s.U2*s.e13-s.U3*s.e12)+
+		s.f12*(s.U3*s.e11-s.U1*s.e13)+
+		s.f13*(s.U1*s.e12-s.U2*s.e11)))
+	jac.Set(6, 11, Deg/G*( // A1/H2
+	s.f11*(s.U2*s.e23-s.U3*s.e22)+
+		s.f12*(s.U3*s.e21-s.U1*s.e23)+
+		s.f13*(s.U1*s.e22-s.U2*s.e21)))
+	jac.Set(6, 12, Deg/G*( // A1/H3
+	s.f11*(s.U2*s.e33-s.U3*s.e32)+
+		s.f12*(s.U3*s.e31-s.U1*s.e33)+
+		s.f13*(s.U1*s.e32-s.U2*s.e31)))
+	jac.Set(6, 19, 1) // A1/C1
+	jac.Set(6, 22,    // A1/F0
+		2*(+s.F0*a1-s.F3*a2+s.F2*a3)-
+			2*af1*s.F0)
+	jac.Set(6, 23, // A1/F1
+		2*(+s.F1*a1+s.F2*a2+s.F3*a3)-
+			2*af1*s.F1)
+	jac.Set(6, 24, // A1/F2
+		2*(-s.F2*a1+s.F1*a2+s.F0*a3)-
+			2*af1*s.F2)
+	jac.Set(6, 25, // A1/F3
+		2*(-s.F3*a1-s.F0*a2+s.F1*a3)-
+			2*af1*s.F3)
 
 	aa2 := s.f21*(a1+s.Z1) + s.f22*(a2+s.Z2) + s.f23*(a3+s.Z3)
 	af2 := s.f21*a1 + s.f22*a2 + s.f23*a3
-	jac.Set(7, 0, (h2*s.f23 - h3*s.f22)*Deg/G)                    // A2/U1
-	jac.Set(7, 1, (h3*s.f21 - h1*s.f23)*Deg/G)                    // A2/U2
-	jac.Set(7, 2, (h1*s.f22 - h2*s.f21)*Deg/G)                    // A2/U3
-	jac.Set(7, 3, -s.f21)                                         // A2/Z1
-	jac.Set(7, 4, -s.f22)                                         // A2/Z2
-	jac.Set(7, 5, -s.f23)                                         // A2/Z3
-	jac.Set(7, 6, 2*Deg/G*(                                       // A2/E0
-		s.f21*(s.H1*( s.E2*s.U2 + s.E3*s.U3) + s.H2*(-s.E1*s.U2 - s.E0*s.U3) + s.H3*( s.E0*s.U2 - s.E1*s.U3)) +
-		s.f22*(s.H1*( s.E0*s.U3 - s.E2*s.U1) + s.H2*( s.E3*s.U3 + s.E1*s.U1) + s.H3*(-s.E2*s.U3 - s.E0*s.U1)) +
-		s.f23*(s.H1*(-s.E3*s.U1 - s.E0*s.U2) + s.H2*( s.E0*s.U1 - s.E3*s.U2) + s.H3*( s.E1*s.U1 + s.E2*s.U2)) ) -
-		2*aa2*s.E0 -
-		2*(s.f21*(-s.E2) + s.f22*( s.E1) + s.f23*( s.E0)) )
-	jac.Set(7, 7, 2*Deg/G*(                                       // A2/E1
-		s.f21*(s.H1*( s.E3*s.U2 - s.E2*s.U3) + s.H2*(-s.E0*s.U2 + s.E1*s.U3) + s.H3*(-s.E1*s.U2 - s.E0*s.U3)) +
-		s.f22*(s.H1*( s.E1*s.U3 - s.E3*s.U1) + s.H2*( s.E2*s.U3 + s.E0*s.U1) + s.H3*( s.E3*s.U3 + s.E1*s.U1)) +
-		s.f23*(s.H1*( s.E2*s.U1 - s.E1*s.U2) + s.H2*(-s.E1*s.U1 - s.E2*s.U2) + s.H3*( s.E0*s.U1 - s.E3*s.U2)) ) -
-		2*aa2*s.E1 -
-		2*(s.f21*( s.E3) + s.f22*( s.E0) + s.f23*(-s.E1)) )
-	jac.Set(7, 8, 2*Deg/G*(                                       // A2/E2
-		s.f21*(s.H1*( s.E0*s.U2 - s.E1*s.U3) + s.H2*( s.E3*s.U2 - s.E2*s.U3) + s.H3*(-s.E2*s.U2 - s.E3*s.U3)) +
-		s.f22*(s.H1*(-s.E2*s.U3 - s.E0*s.U1) + s.H2*( s.E1*s.U3 - s.E3*s.U1) + s.H3*(-s.E0*s.U3 + s.E2*s.U1)) +
-		s.f23*(s.H1*( s.E1*s.U1 + s.E2*s.U2) + s.H2*( s.E2*s.U1 - s.E1*s.U2) + s.H3*( s.E3*s.U1 + s.E0*s.U2)) ) -
-		2*aa2*s.E2 -
-		2*(s.f21*(-s.E0) + s.f22*( s.E3) + s.f23*(-s.E2)) )
-	jac.Set(7, 9, 2*Deg/G*(                                       // A2/E3
-		s.f21*(s.H1*( s.E1*s.U2 + s.E0*s.U3) + s.H2*( s.E2*s.U2 + s.E3*s.U3) + s.H3*( s.E3*s.U2 - s.E2*s.U3)) +
-		s.f22*(s.H1*(-s.E3*s.U3 - s.E1*s.U1) + s.H2*( s.E0*s.U3 - s.E2*s.U1) + s.H3*( s.E1*s.U3 - s.E3*s.U1)) +
-		s.f23*(s.H1*(-s.E0*s.U1 + s.E3*s.U2) + s.H2*(-s.E3*s.U1 - s.E0*s.U2) + s.H3*( s.E2*s.U1 - s.E1*s.U2)) ) -
-		2*aa2*s.E3 -
-		2*(s.f21*( s.E1) + s.f22*( s.E2) + s.f23*( s.E3)) )
-	jac.Set(7, 10, Deg/G*(                                      // A2/H1
-		s.f21*(s.U2*s.e13 - s.U3*s.e12) +
-		s.f22*(s.U3*s.e11 - s.U1*s.e13) +
-		s.f23*(s.U1*s.e12 - s.U2*s.e11) ))
-	jac.Set(7, 11, Deg/G*(                                      // A2/H2
-		s.f21*(s.U2*s.e23 - s.U3*s.e22) +
-		s.f22*(s.U3*s.e21 - s.U1*s.e23) +
-		s.f23*(s.U1*s.e22 - s.U2*s.e21) ))
-	jac.Set(7, 12, Deg/G*(                                      // A2/H3
-		s.f21*(s.U2*s.e33 - s.U3*s.e32) +
-		s.f22*(s.U3*s.e31 - s.U1*s.e33) +
-		s.f23*(s.U1*s.e32 - s.U2*s.e31) ))
-	jac.Set(7, 20, 1)                                             // A2/C2
-	jac.Set(7, 22,                                                // A2/F0
-		2*(+s.F3*a1 + s.F0*a2 - s.F1*a3) -
-		2*af2*s.F0)
-	jac.Set(7, 23,                                                // A2/F1
-		2*(+s.F2*a1 - s.F1*a2 - s.F0*a3) -
-		2*af2*s.F1)
-	jac.Set(7, 24,                                                // A2/F2
-		2*(+s.F1*a1 + s.F2*a2 + s.F3*a3) -
-		2*af2*s.F2)
-	jac.Set(7, 25,                                                // A2/F3
-		2*(+s.F0*a1 - s.F3*a2 + s.F2*a3) -
-		2*af2*s.F3)
+	jac.Set(7, 0, (h2*s.f23-h3*s.f22)*Deg/G) // A2/U1
+	jac.Set(7, 1, (h3*s.f21-h1*s.f23)*Deg/G) // A2/U2
+	jac.Set(7, 2, (h1*s.f22-h2*s.f21)*Deg/G) // A2/U3
+	jac.Set(7, 3, -s.f21)                    // A2/Z1
+	jac.Set(7, 4, -s.f22)                    // A2/Z2
+	jac.Set(7, 5, -s.f23)                    // A2/Z3
+	jac.Set(7, 6, 2*Deg/G*(                  // A2/E0
+	s.f21*(s.H1*(s.E2*s.U2+s.E3*s.U3)+s.H2*(-s.E1*s.U2-s.E0*s.U3)+s.H3*(s.E0*s.U2-s.E1*s.U3))+
+		s.f22*(s.H1*(s.E0*s.U3-s.E2*s.U1)+s.H2*(s.E3*s.U3+s.E1*s.U1)+s.H3*(-s.E2*s.U3-s.E0*s.U1))+
+		s.f23*(s.H1*(-s.E3*s.U1-s.E0*s.U2)+s.H2*(s.E0*s.U1-s.E3*s.U2)+s.H3*(s.E1*s.U1+s.E2*s.U2)))-
+		2*aa2*s.E0-
+		2*(s.f21*(-s.E2)+s.f22*(s.E1)+s.f23*(s.E0)))
+	jac.Set(7, 7, 2*Deg/G*( // A2/E1
+	s.f21*(s.H1*(s.E3*s.U2-s.E2*s.U3)+s.H2*(-s.E0*s.U2+s.E1*s.U3)+s.H3*(-s.E1*s.U2-s.E0*s.U3))+
+		s.f22*(s.H1*(s.E1*s.U3-s.E3*s.U1)+s.H2*(s.E2*s.U3+s.E0*s.U1)+s.H3*(s.E3*s.U3+s.E1*s.U1))+
+		s.f23*(s.H1*(s.E2*s.U1-s.E1*s.U2)+s.H2*(-s.E1*s.U1-s.E2*s.U2)+s.H3*(s.E0*s.U1-s.E3*s.U2)))-
+		2*aa2*s.E1-
+		2*(s.f21*(s.E3)+s.f22*(s.E0)+s.f23*(-s.E1)))
+	jac.Set(7, 8, 2*Deg/G*( // A2/E2
+	s.f21*(s.H1*(s.E0*s.U2-s.E1*s.U3)+s.H2*(s.E3*s.U2-s.E2*s.U3)+s.H3*(-s.E2*s.U2-s.E3*s.U3))+
+		s.f22*(s.H1*(-s.E2*s.U3-s.E0*s.U1)+s.H2*(s.E1*s.U3-s.E3*s.U1)+s.H3*(-s.E0*s.U3+s.E2*s.U1))+
+		s.f23*(s.H1*(s.E1*s.U1+s.E2*s.U2)+s.H2*(s.E2*s.U1-s.E1*s.U2)+s.H3*(s.E3*s.U1+s.E0*s.U2)))-
+		2*aa2*s.E2-
+		2*(s.f21*(-s.E0)+s.f22*(s.E3)+s.f23*(-s.E2)))
+	jac.Set(7, 9, 2*Deg/G*( // A2/E3
+	s.f21*(s.H1*(s.E1*s.U2+s.E0*s.U3)+s.H2*(s.E2*s.U2+s.E3*s.U3)+s.H3*(s.E3*s.U2-s.E2*s.U3))+
+		s.f22*(s.H1*(-s.E3*s.U3-s.E1*s.U1)+s.H2*(s.E0*s.U3-s.E2*s.U1)+s.H3*(s.E1*s.U3-s.E3*s.U1))+
+		s.f23*(s.H1*(-s.E0*s.U1+s.E3*s.U2)+s.H2*(-s.E3*s.U1-s.E0*s.U2)+s.H3*(s.E2*s.U1-s.E1*s.U2)))-
+		2*aa2*s.E3-
+		2*(s.f21*(s.E1)+s.f22*(s.E2)+s.f23*(s.E3)))
+	jac.Set(7, 10, Deg/G*( // A2/H1
+	s.f21*(s.U2*s.e13-s.U3*s.e12)+
+		s.f22*(s.U3*s.e11-s.U1*s.e13)+
+		s.f23*(s.U1*s.e12-s.U2*s.e11)))
+	jac.Set(7, 11, Deg/G*( // A2/H2
+	s.f21*(s.U2*s.e23-s.U3*s.e22)+
+		s.f22*(s.U3*s.e21-s.U1*s.e23)+
+		s.f23*(s.U1*s.e22-s.U2*s.e21)))
+	jac.Set(7, 12, Deg/G*( // A2/H3
+	s.f21*(s.U2*s.e33-s.U3*s.e32)+
+		s.f22*(s.U3*s.e31-s.U1*s.e33)+
+		s.f23*(s.U1*s.e32-s.U2*s.e31)))
+	jac.Set(7, 20, 1) // A2/C2
+	jac.Set(7, 22,    // A2/F0
+		2*(+s.F3*a1+s.F0*a2-s.F1*a3)-
+			2*af2*s.F0)
+	jac.Set(7, 23, // A2/F1
+		2*(+s.F2*a1-s.F1*a2-s.F0*a3)-
+			2*af2*s.F1)
+	jac.Set(7, 24, // A2/F2
+		2*(+s.F1*a1+s.F2*a2+s.F3*a3)-
+			2*af2*s.F2)
+	jac.Set(7, 25, // A2/F3
+		2*(+s.F0*a1-s.F3*a2+s.F2*a3)-
+			2*af2*s.F3)
 
 	aa3 := s.f31*(a1+s.Z1) + s.f32*(a2+s.Z2) + s.f33*(a3+s.Z3)
 	af3 := s.f31*a1 + s.f32*a2 + s.f33*a3
-	jac.Set(8, 0, (h2*s.f33 - h3*s.f32)*Deg/G)                    // A3/U1
-	jac.Set(8, 1, (h3*s.f31 - h1*s.f33)*Deg/G)                    // A3/U2
-	jac.Set(8, 2, (h1*s.f32 - h2*s.f31)*Deg/G)                    // A3/U3
-	jac.Set(8, 3, -s.f31)                                         // A3/Z1
-	jac.Set(8, 4, -s.f32)                                         // A3/Z2
-	jac.Set(8, 5, -s.f33)                                         // A3/Z3
-	jac.Set(8, 6, 2*Deg/G*(                                       // A3/E0
-		s.f31*(s.H1*( s.E2*s.U2 + s.E3*s.U3) + s.H2*(-s.E1*s.U2 - s.E0*s.U3) + s.H3*( s.E0*s.U2 - s.E1*s.U3)) +
-		s.f32*(s.H1*( s.E0*s.U3 - s.E2*s.U1) + s.H2*( s.E3*s.U3 + s.E1*s.U1) + s.H3*(-s.E2*s.U3 - s.E0*s.U1)) +
-		s.f33*(s.H1*(-s.E3*s.U1 - s.E0*s.U2) + s.H2*( s.E0*s.U1 - s.E3*s.U2) + s.H3*( s.E1*s.U1 + s.E2*s.U2)) ) -
-		2*aa3*s.E0 -
-		2*(s.f31*(-s.E2) + s.f32*( s.E1) + s.f33*( s.E0)) )
-	jac.Set(8, 7, 2*Deg/G*(                                       // A3/E1
-		s.f31*(s.H1*( s.E3*s.U2 - s.E2*s.U3) + s.H2*(-s.E0*s.U2 + s.E1*s.U3) + s.H3*(-s.E1*s.U2 - s.E0*s.U3)) +
-		s.f32*(s.H1*( s.E1*s.U3 - s.E3*s.U1) + s.H2*( s.E2*s.U3 + s.E0*s.U1) + s.H3*( s.E3*s.U3 + s.E1*s.U1)) +
-		s.f33*(s.H1*( s.E2*s.U1 - s.E1*s.U2) + s.H2*(-s.E1*s.U1 - s.E2*s.U2) + s.H3*( s.E0*s.U1 - s.E3*s.U2)) ) -
-		2*aa3*s.E1 -
-		2*(s.f31*( s.E3) + s.f32*( s.E0) + s.f33*(-s.E1)) )
-	jac.Set(8, 8, 2*Deg/G*(                                       // A3/E2
-		s.f31*(s.H1*( s.E0*s.U2 - s.E1*s.U3) + s.H2*( s.E3*s.U2 - s.E2*s.U3) + s.H3*(-s.E2*s.U2 - s.E3*s.U3)) +
-		s.f32*(s.H1*(-s.E2*s.U3 - s.E0*s.U1) + s.H2*( s.E1*s.U3 - s.E3*s.U1) + s.H3*(-s.E0*s.U3 + s.E2*s.U1)) +
-		s.f33*(s.H1*( s.E1*s.U1 + s.E2*s.U2) + s.H2*( s.E2*s.U1 - s.E1*s.U2) + s.H3*( s.E3*s.U1 + s.E0*s.U2)) ) -
-		2*aa3*s.E2 -
-		2*(s.f31*(-s.E0) + s.f32*( s.E3) + s.f33*(-s.E2)) )
-	jac.Set(8, 9, 2*Deg/G*(                                       // A3/E3
-		s.f31*(s.H1*( s.E1*s.U2 + s.E0*s.U3) + s.H2*( s.E2*s.U2 + s.E3*s.U3) + s.H3*( s.E3*s.U2 - s.E2*s.U3)) +
-		s.f32*(s.H1*(-s.E3*s.U3 - s.E1*s.U1) + s.H2*( s.E0*s.U3 - s.E2*s.U1) + s.H3*( s.E1*s.U3 - s.E3*s.U1)) +
-		s.f33*(s.H1*(-s.E0*s.U1 + s.E3*s.U2) + s.H2*(-s.E3*s.U1 - s.E0*s.U2) + s.H3*( s.E2*s.U1 - s.E1*s.U2)) ) -
-		2*aa3*s.E3 -
-		2*(s.f31*( s.E1) + s.f32*( s.E2) + s.f33*( s.E3)) )
-	jac.Set(8, 10, Deg/G*(                                      // A3/H1
-		s.f31*(s.U2*s.e13 - s.U3*s.e12) +
-		s.f32*(s.U3*s.e11 - s.U1*s.e13) +
-		s.f33*(s.U1*s.e12 - s.U2*s.e11) ))
-	jac.Set(8, 11, Deg/G*(                                      // A3/H2
-		s.f31*(s.U2*s.e23 - s.U3*s.e22) +
-		s.f32*(s.U3*s.e21 - s.U1*s.e23) +
-		s.f33*(s.U1*s.e22 - s.U2*s.e21) ))
-	jac.Set(8, 12, Deg/G*(                                      // A3/H3
-		s.f31*(s.U2*s.e33 - s.U3*s.e32) +
-		s.f32*(s.U3*s.e31 - s.U1*s.e33) +
-		s.f33*(s.U1*s.e32 - s.U2*s.e31) ))
-	jac.Set(8, 21, 1)                                             // A3/C3
-	jac.Set(8, 22,                                                // A3/F0
-		2*(-s.F2*a1 + s.F1*a2 + s.F0*a3) -
-		2*af3*s.F0)
-	jac.Set(8, 23,                                                // A3/F1
-		2*(+s.F3*a1 + s.F0*a2 - s.F1*a3) -
-		2*af3*s.F1)
-	jac.Set(8, 24,                                                // A3/F2
-		2*(-s.F0*a1 + s.F3*a2 - s.F2*a3) -
-		2*af3*s.F2)
-	jac.Set(8, 25,                                                // A3/F3
-		2*(+s.F1*a1 + s.F2*a2 + s.F3*a3) -
-		2*af3*s.F3)
+	jac.Set(8, 0, (h2*s.f33-h3*s.f32)*Deg/G) // A3/U1
+	jac.Set(8, 1, (h3*s.f31-h1*s.f33)*Deg/G) // A3/U2
+	jac.Set(8, 2, (h1*s.f32-h2*s.f31)*Deg/G) // A3/U3
+	jac.Set(8, 3, -s.f31)                    // A3/Z1
+	jac.Set(8, 4, -s.f32)                    // A3/Z2
+	jac.Set(8, 5, -s.f33)                    // A3/Z3
+	jac.Set(8, 6, 2*Deg/G*(                  // A3/E0
+	s.f31*(s.H1*(s.E2*s.U2+s.E3*s.U3)+s.H2*(-s.E1*s.U2-s.E0*s.U3)+s.H3*(s.E0*s.U2-s.E1*s.U3))+
+		s.f32*(s.H1*(s.E0*s.U3-s.E2*s.U1)+s.H2*(s.E3*s.U3+s.E1*s.U1)+s.H3*(-s.E2*s.U3-s.E0*s.U1))+
+		s.f33*(s.H1*(-s.E3*s.U1-s.E0*s.U2)+s.H2*(s.E0*s.U1-s.E3*s.U2)+s.H3*(s.E1*s.U1+s.E2*s.U2)))-
+		2*aa3*s.E0-
+		2*(s.f31*(-s.E2)+s.f32*(s.E1)+s.f33*(s.E0)))
+	jac.Set(8, 7, 2*Deg/G*( // A3/E1
+	s.f31*(s.H1*(s.E3*s.U2-s.E2*s.U3)+s.H2*(-s.E0*s.U2+s.E1*s.U3)+s.H3*(-s.E1*s.U2-s.E0*s.U3))+
+		s.f32*(s.H1*(s.E1*s.U3-s.E3*s.U1)+s.H2*(s.E2*s.U3+s.E0*s.U1)+s.H3*(s.E3*s.U3+s.E1*s.U1))+
+		s.f33*(s.H1*(s.E2*s.U1-s.E1*s.U2)+s.H2*(-s.E1*s.U1-s.E2*s.U2)+s.H3*(s.E0*s.U1-s.E3*s.U2)))-
+		2*aa3*s.E1-
+		2*(s.f31*(s.E3)+s.f32*(s.E0)+s.f33*(-s.E1)))
+	jac.Set(8, 8, 2*Deg/G*( // A3/E2
+	s.f31*(s.H1*(s.E0*s.U2-s.E1*s.U3)+s.H2*(s.E3*s.U2-s.E2*s.U3)+s.H3*(-s.E2*s.U2-s.E3*s.U3))+
+		s.f32*(s.H1*(-s.E2*s.U3-s.E0*s.U1)+s.H2*(s.E1*s.U3-s.E3*s.U1)+s.H3*(-s.E0*s.U3+s.E2*s.U1))+
+		s.f33*(s.H1*(s.E1*s.U1+s.E2*s.U2)+s.H2*(s.E2*s.U1-s.E1*s.U2)+s.H3*(s.E3*s.U1+s.E0*s.U2)))-
+		2*aa3*s.E2-
+		2*(s.f31*(-s.E0)+s.f32*(s.E3)+s.f33*(-s.E2)))
+	jac.Set(8, 9, 2*Deg/G*( // A3/E3
+	s.f31*(s.H1*(s.E1*s.U2+s.E0*s.U3)+s.H2*(s.E2*s.U2+s.E3*s.U3)+s.H3*(s.E3*s.U2-s.E2*s.U3))+
+		s.f32*(s.H1*(-s.E3*s.U3-s.E1*s.U1)+s.H2*(s.E0*s.U3-s.E2*s.U1)+s.H3*(s.E1*s.U3-s.E3*s.U1))+
+		s.f33*(s.H1*(-s.E0*s.U1+s.E3*s.U2)+s.H2*(-s.E3*s.U1-s.E0*s.U2)+s.H3*(s.E2*s.U1-s.E1*s.U2)))-
+		2*aa3*s.E3-
+		2*(s.f31*(s.E1)+s.f32*(s.E2)+s.f33*(s.E3)))
+	jac.Set(8, 10, Deg/G*( // A3/H1
+	s.f31*(s.U2*s.e13-s.U3*s.e12)+
+		s.f32*(s.U3*s.e11-s.U1*s.e13)+
+		s.f33*(s.U1*s.e12-s.U2*s.e11)))
+	jac.Set(8, 11, Deg/G*( // A3/H2
+	s.f31*(s.U2*s.e23-s.U3*s.e22)+
+		s.f32*(s.U3*s.e21-s.U1*s.e23)+
+		s.f33*(s.U1*s.e22-s.U2*s.e21)))
+	jac.Set(8, 12, Deg/G*( // A3/H3
+	s.f31*(s.U2*s.e33-s.U3*s.e32)+
+		s.f32*(s.U3*s.e31-s.U1*s.e33)+
+		s.f33*(s.U1*s.e32-s.U2*s.e31)))
+	jac.Set(8, 21, 1) // A3/C3
+	jac.Set(8, 22,    // A3/F0
+		2*(-s.F2*a1+s.F1*a2+s.F0*a3)-
+			2*af3*s.F0)
+	jac.Set(8, 23, // A3/F1
+		2*(+s.F3*a1+s.F0*a2-s.F1*a3)-
+			2*af3*s.F1)
+	jac.Set(8, 24, // A3/F2
+		2*(-s.F0*a1+s.F3*a2-s.F2*a3)-
+			2*af3*s.F2)
+	jac.Set(8, 25, // A3/F3
+		2*(+s.F1*a1+s.F2*a2+s.F3*a3)-
+			2*af3*s.F3)
 
 	b1 := s.f11*h1 + s.f12*h2 + s.f13*h3
 	bf1 := b1 + s.D1
-	jac.Set(9, 6,                                                 // B1/E0
-		2*( s.E0*s.H1 + s.E3*s.H2 - s.E2*s.H3)*s.f11 +
-		2*(-s.E3*s.H1 + s.E0*s.H2 + s.E1*s.H3)*s.f12 +
-		2*( s.E2*s.H1 - s.E1*s.H2 + s.E0*s.H3)*s.f13 -
-		2*b1*s.E0)
-	jac.Set(9, 7,                                                 // B1/E1
-		2*( s.E1*s.H1 + s.E2*s.H2 + s.E3*s.H3)*s.f11 +
-		2*( s.E2*s.H1 - s.E1*s.H2 + s.E0*s.H3)*s.f12 +
-		2*( s.E3*s.H1 - s.E0*s.H2 - s.E1*s.H3)*s.f13 -
-		2*b1*s.E1)
-	jac.Set(9, 8,                                                 // B1/E2
-		2*(-s.E2*s.H1 + s.E1*s.H2 - s.E0*s.H3)*s.f11 +
-		2*( s.E1*s.H1 + s.E2*s.H2 + s.E3*s.H3)*s.f12 +
-		2*( s.E0*s.H1 + s.E3*s.H2 - s.E2*s.H3)*s.f13 -
-		2*b1*s.E2)
-	jac.Set(9, 9,                                                 // B1/E3
-		2*(-s.E3*s.H1 + s.E0*s.H2 + s.E1*s.H3)*s.f11 +
-		2*(-s.E0*s.H1 - s.E3*s.H2 + s.E2*s.H3)*s.f12 +
-		2*( s.E1*s.H1 + s.E2*s.H2 + s.E3*s.H3)*s.f13 -
-		2*b1*s.E3)
-	jac.Set(9, 10, s.e11*s.f11 + s.e12*s.f12 + s.e13*s.f13 )      // B1/H1
-	jac.Set(9, 11, s.e21*s.f11 + s.e22*s.f12 + s.e23*s.f13 )      // B1/H2
-	jac.Set(9, 12, s.e31*s.f11 + s.e32*s.f12 + s.e33*s.f13 )      // B1/H3
-	jac.Set(9, 22, 2*( h1*s.F0 - h2*s.F3 + h3*s.F2) -             // B1/F0
+	jac.Set(9, 6, // B1/E0
+		2*(s.E0*s.H1+s.E3*s.H2-s.E2*s.H3)*s.f11+
+			2*(-s.E3*s.H1+s.E0*s.H2+s.E1*s.H3)*s.f12+
+			2*(s.E2*s.H1-s.E1*s.H2+s.E0*s.H3)*s.f13-
+			2*b1*s.E0)
+	jac.Set(9, 7, // B1/E1
+		2*(s.E1*s.H1+s.E2*s.H2+s.E3*s.H3)*s.f11+
+			2*(s.E2*s.H1-s.E1*s.H2+s.E0*s.H3)*s.f12+
+			2*(s.E3*s.H1-s.E0*s.H2-s.E1*s.H3)*s.f13-
+			2*b1*s.E1)
+	jac.Set(9, 8, // B1/E2
+		2*(-s.E2*s.H1+s.E1*s.H2-s.E0*s.H3)*s.f11+
+			2*(s.E1*s.H1+s.E2*s.H2+s.E3*s.H3)*s.f12+
+			2*(s.E0*s.H1+s.E3*s.H2-s.E2*s.H3)*s.f13-
+			2*b1*s.E2)
+	jac.Set(9, 9, // B1/E3
+		2*(-s.E3*s.H1+s.E0*s.H2+s.E1*s.H3)*s.f11+
+			2*(-s.E0*s.H1-s.E3*s.H2+s.E2*s.H3)*s.f12+
+			2*(s.E1*s.H1+s.E2*s.H2+s.E3*s.H3)*s.f13-
+			2*b1*s.E3)
+	jac.Set(9, 10, s.e11*s.f11+s.e12*s.f12+s.e13*s.f13) // B1/H1
+	jac.Set(9, 11, s.e21*s.f11+s.e22*s.f12+s.e23*s.f13) // B1/H2
+	jac.Set(9, 12, s.e31*s.f11+s.e32*s.f12+s.e33*s.f13) // B1/H3
+	jac.Set(9, 22, 2*(h1*s.F0-h2*s.F3+h3*s.F2)-         // B1/F0
 		2*bf1*s.F0)
-	jac.Set(9, 23, 2*( h1*s.F1 + h2*s.F2 + h3*s.F3) -             // B1/F1
+	jac.Set(9, 23, 2*(h1*s.F1+h2*s.F2+h3*s.F3)- // B1/F1
 		2*bf1*s.F1)
-	jac.Set(9, 24, 2*(-h1*s.F2 + h2*s.F1 + h3*s.F0) -             // B1/F2
+	jac.Set(9, 24, 2*(-h1*s.F2+h2*s.F1+h3*s.F0)- // B1/F2
 		2*bf1*s.F2)
-	jac.Set(9, 25, 2*(-h1*s.F3 - h2*s.F0 + h3*s.F1) -             // B1/F3
+	jac.Set(9, 25, 2*(-h1*s.F3-h2*s.F0+h3*s.F1)- // B1/F3
 		2*bf1*s.F3)
-	jac.Set(9, 26, 1)                                             // B1/D1
+	jac.Set(9, 26, 1) // B1/D1
 
 	b2 := s.f21*h1 + s.f22*h2 + s.f23*h3
 	bf2 := b2 + s.D2
-	jac.Set(10, 6,                                                // B2/E0
-		2*( s.E0*s.H1 + s.E3*s.H2 - s.E2*s.H3)*s.f21 +
-		2*(-s.E3*s.H1 + s.E0*s.H2 + s.E1*s.H3)*s.f22 +
-		2*( s.E2*s.H1 - s.E1*s.H2 + s.E0*s.H3)*s.f23 -
-		2*b2*s.E0)
-	jac.Set(10, 7,                                                // B2/E1
-		2*( s.E1*s.H1 + s.E2*s.H2 + s.E3*s.H3)*s.f21 +
-		2*( s.E2*s.H1 - s.E1*s.H2 + s.E0*s.H3)*s.f22 +
-		2*( s.E3*s.H1 - s.E0*s.H2 - s.E1*s.H3)*s.f23 -
-		2*b2*s.E1)
-	jac.Set(10, 8,                                                // B2/E2
-		2*(-s.E2*s.H1 + s.E1*s.H2 - s.E0*s.H3)*s.f21 +
-		2*( s.E1*s.H1 + s.E2*s.H2 + s.E3*s.H3)*s.f22 +
-		2*( s.E0*s.H1 + s.E3*s.H2 - s.E2*s.H3)*s.f23 -
-		2*b2*s.E2)
-	jac.Set(10, 9,                                                // B2/E3
-		2*(-s.E3*s.H1 + s.E0*s.H2 + s.E1*s.H3)*s.f21 +
-		2*(-s.E0*s.H1 - s.E3*s.H2 + s.E2*s.H3)*s.f22 +
-		2*( s.E1*s.H1 + s.E2*s.H2 + s.E3*s.H3)*s.f23 -
-		2*b2*s.E3)
-	jac.Set(10, 10, s.e11*s.f21 + s.e12*s.f22 + s.e13*s.f23 )     // B2/H1
-	jac.Set(10, 11, s.e21*s.f21 + s.e22*s.f22 + s.e23*s.f23 )     // B2/H2
-	jac.Set(10, 12, s.e31*s.f21 + s.e32*s.f22 + s.e33*s.f23 )     // B2/H3
-	jac.Set(10, 22, 2*( h1*s.F3 + h2*s.F0 - h3*s.F1) -            // B2/F0
+	jac.Set(10, 6, // B2/E0
+		2*(s.E0*s.H1+s.E3*s.H2-s.E2*s.H3)*s.f21+
+			2*(-s.E3*s.H1+s.E0*s.H2+s.E1*s.H3)*s.f22+
+			2*(s.E2*s.H1-s.E1*s.H2+s.E0*s.H3)*s.f23-
+			2*b2*s.E0)
+	jac.Set(10, 7, // B2/E1
+		2*(s.E1*s.H1+s.E2*s.H2+s.E3*s.H3)*s.f21+
+			2*(s.E2*s.H1-s.E1*s.H2+s.E0*s.H3)*s.f22+
+			2*(s.E3*s.H1-s.E0*s.H2-s.E1*s.H3)*s.f23-
+			2*b2*s.E1)
+	jac.Set(10, 8, // B2/E2
+		2*(-s.E2*s.H1+s.E1*s.H2-s.E0*s.H3)*s.f21+
+			2*(s.E1*s.H1+s.E2*s.H2+s.E3*s.H3)*s.f22+
+			2*(s.E0*s.H1+s.E3*s.H2-s.E2*s.H3)*s.f23-
+			2*b2*s.E2)
+	jac.Set(10, 9, // B2/E3
+		2*(-s.E3*s.H1+s.E0*s.H2+s.E1*s.H3)*s.f21+
+			2*(-s.E0*s.H1-s.E3*s.H2+s.E2*s.H3)*s.f22+
+			2*(s.E1*s.H1+s.E2*s.H2+s.E3*s.H3)*s.f23-
+			2*b2*s.E3)
+	jac.Set(10, 10, s.e11*s.f21+s.e12*s.f22+s.e13*s.f23) // B2/H1
+	jac.Set(10, 11, s.e21*s.f21+s.e22*s.f22+s.e23*s.f23) // B2/H2
+	jac.Set(10, 12, s.e31*s.f21+s.e32*s.f22+s.e33*s.f23) // B2/H3
+	jac.Set(10, 22, 2*(h1*s.F3+h2*s.F0-h3*s.F1)-         // B2/F0
 		2*bf2*s.F0)
-	jac.Set(10, 23, 2*( h1*s.F2 - h2*s.F1 - h3*s.F0) -            // B2/F1
+	jac.Set(10, 23, 2*(h1*s.F2-h2*s.F1-h3*s.F0)- // B2/F1
 		2*bf2*s.F1)
-	jac.Set(10, 24, 2*( h1*s.F1 + h2*s.F2 + h3*s.F3) -            // B2/F2
+	jac.Set(10, 24, 2*(h1*s.F1+h2*s.F2+h3*s.F3)- // B2/F2
 		2*bf2*s.F2)
-	jac.Set(10, 25, 2*( h1*s.F0 - h2*s.F3 + h3*s.F2) -            // B2/F3
+	jac.Set(10, 25, 2*(h1*s.F0-h2*s.F3+h3*s.F2)- // B2/F3
 		2*bf2*s.F3)
-	jac.Set(10, 27, 1)                                            // B2/D2
+	jac.Set(10, 27, 1) // B2/D2
 
 	b3 := s.f31*h1 + s.f32*h2 + s.f33*h3
 	bf3 := b3 + s.D3
-	jac.Set(11, 6,                                                // B3/E0
-		2*( s.E0*s.H1 + s.E3*s.H2 - s.E2*s.H3)*s.f31 +
-		2*(-s.E3*s.H1 + s.E0*s.H2 + s.E1*s.H3)*s.f32 +
-		2*( s.E2*s.H1 - s.E1*s.H2 + s.E0*s.H3)*s.f33 -
-		2*b3*s.E0)
-	jac.Set(11, 7,                                                // B3/E1
-		2*( s.E1*s.H1 + s.E2*s.H2 + s.E3*s.H3)*s.f31 +
-		2*( s.E2*s.H1 - s.E1*s.H2 + s.E0*s.H3)*s.f32 +
-		2*( s.E3*s.H1 - s.E0*s.H2 - s.E1*s.H3)*s.f33 -
-		2*b3*s.E1)
-	jac.Set(11, 8,                                                // B3/E2
-		2*(-s.E2*s.H1 + s.E1*s.H2 - s.E0*s.H3)*s.f31 +
-		2*( s.E1*s.H1 + s.E2*s.H2 + s.E3*s.H3)*s.f32 +
-		2*( s.E0*s.H1 + s.E3*s.H2 - s.E2*s.H3)*s.f33 -
-		2*b3*s.E2)
-	jac.Set(11, 9,                                                // B3/E2
-		2*(-s.E3*s.H1 + s.E0*s.H2 + s.E1*s.H3)*s.f31 +
-		2*(-s.E0*s.H1 - s.E3*s.H2 + s.E2*s.H3)*s.f32 +
-		2*( s.E1*s.H1 + s.E2*s.H2 + s.E3*s.H3)*s.f33 -
-		2*b3*s.E3)
-	jac.Set(11, 10, s.e11*s.f31 + s.e12*s.f32 + s.e13*s.f33 )     // B3/H1
-	jac.Set(11, 11, s.e21*s.f31 + s.e22*s.f32 + s.e23*s.f33 )     // B3/H2
-	jac.Set(11, 12, s.e31*s.f31 + s.e32*s.f32 + s.e33*s.f33 )     // B3/H3
-	jac.Set(11, 22, 2*(-h1*s.F2 + h2*s.F1 + h3*s.F0) -            // B3/F0
+	jac.Set(11, 6, // B3/E0
+		2*(s.E0*s.H1+s.E3*s.H2-s.E2*s.H3)*s.f31+
+			2*(-s.E3*s.H1+s.E0*s.H2+s.E1*s.H3)*s.f32+
+			2*(s.E2*s.H1-s.E1*s.H2+s.E0*s.H3)*s.f33-
+			2*b3*s.E0)
+	jac.Set(11, 7, // B3/E1
+		2*(s.E1*s.H1+s.E2*s.H2+s.E3*s.H3)*s.f31+
+			2*(s.E2*s.H1-s.E1*s.H2+s.E0*s.H3)*s.f32+
+			2*(s.E3*s.H1-s.E0*s.H2-s.E1*s.H3)*s.f33-
+			2*b3*s.E1)
+	jac.Set(11, 8, // B3/E2
+		2*(-s.E2*s.H1+s.E1*s.H2-s.E0*s.H3)*s.f31+
+			2*(s.E1*s.H1+s.E2*s.H2+s.E3*s.H3)*s.f32+
+			2*(s.E0*s.H1+s.E3*s.H2-s.E2*s.H3)*s.f33-
+			2*b3*s.E2)
+	jac.Set(11, 9, // B3/E2
+		2*(-s.E3*s.H1+s.E0*s.H2+s.E1*s.H3)*s.f31+
+			2*(-s.E0*s.H1-s.E3*s.H2+s.E2*s.H3)*s.f32+
+			2*(s.E1*s.H1+s.E2*s.H2+s.E3*s.H3)*s.f33-
+			2*b3*s.E3)
+	jac.Set(11, 10, s.e11*s.f31+s.e12*s.f32+s.e13*s.f33) // B3/H1
+	jac.Set(11, 11, s.e21*s.f31+s.e22*s.f32+s.e23*s.f33) // B3/H2
+	jac.Set(11, 12, s.e31*s.f31+s.e32*s.f32+s.e33*s.f33) // B3/H3
+	jac.Set(11, 22, 2*(-h1*s.F2+h2*s.F1+h3*s.F0)-        // B3/F0
 		2*bf3*s.F0)
-	jac.Set(11, 23, 2*( h1*s.F3 + h2*s.F0 - h3*s.F1) -            // B3/F1
+	jac.Set(11, 23, 2*(h1*s.F3+h2*s.F0-h3*s.F1)- // B3/F1
 		2*bf3*s.F1)
-	jac.Set(11, 24, 2*(-h1*s.F0 + h2*s.F3 - h3*s.F2) -            // B3/F2
+	jac.Set(11, 24, 2*(-h1*s.F0+h2*s.F3-h3*s.F2)- // B3/F2
 		2*bf3*s.F2)
-	jac.Set(11, 25, 2*( h1*s.F1 + h2*s.F2 + h3*s.F3) -            // B3/F3
+	jac.Set(11, 25, 2*(h1*s.F1+h2*s.F2+h3*s.F3)- // B3/F3
 		2*bf3*s.F3)
-	jac.Set(11, 28, 1)                                            // B3/D3
+	jac.Set(11, 28, 1) // B3/D3
 
 	//TODO westphae: fix these
 	/*
-	m1 :=  s.N1*s.e11 + s.N2*s.e21 + s.N3*s.e31 + s.L1
-	m2 :=  s.N1*s.e12 + s.N2*s.e22 + s.N3*s.e32 + s.L2
-	m3 :=  s.N1*s.e13 + s.N2*s.e23 + s.N3*s.e33 + s.L3
+		m1 :=  s.N1*s.e11 + s.N2*s.e21 + s.N3*s.e31 + s.L1
+		m2 :=  s.N1*s.e12 + s.N2*s.e22 + s.N3*s.e32 + s.L2
+		m3 :=  s.N1*s.e13 + s.N2*s.e23 + s.N3*s.e33 + s.L3
 
-	m.M1 = s.f11*m1 + s.f21*m2 + s.f31*m3 + s.L1
-	jac.Set(12, 6, 2*(+s.E0*s.N1 - s.E3*s.N2 + s.E2*s.N3))         // M1/E0
-	jac.Set(12, 7, 2*(+s.E1*s.N1 + s.E2*s.N2 + s.E3*s.N3))         // M1/E1
-	jac.Set(12, 8, 2*(-s.E2*s.N1 + s.E1*s.N2 + s.E0*s.N3))         // M1/E2
-	jac.Set(12, 9, 2*(-s.E3*s.N1 - s.E0*s.N2 + s.E1*s.N3))         // M1/E3
-	jac.Set(12, 13, 2*(s.E1*s.E1+s.E0*s.E0-0.5))                   // M1/N1
-	jac.Set(12, 14, 2*(s.E1*s.E2-s.E0*s.E3))                       // M1/N2
-	jac.Set(12, 15, 2*(s.E1*s.E3+s.E0*s.E2))                       // M1/N3
-	jac.Set(12, 29, 1)                                             // M1/L1
+		m.M1 = s.f11*m1 + s.f21*m2 + s.f31*m3 + s.L1
+		jac.Set(12, 6, 2*(+s.E0*s.N1 - s.E3*s.N2 + s.E2*s.N3))         // M1/E0
+		jac.Set(12, 7, 2*(+s.E1*s.N1 + s.E2*s.N2 + s.E3*s.N3))         // M1/E1
+		jac.Set(12, 8, 2*(-s.E2*s.N1 + s.E1*s.N2 + s.E0*s.N3))         // M1/E2
+		jac.Set(12, 9, 2*(-s.E3*s.N1 - s.E0*s.N2 + s.E1*s.N3))         // M1/E3
+		jac.Set(12, 13, 2*(s.E1*s.E1+s.E0*s.E0-0.5))                   // M1/N1
+		jac.Set(12, 14, 2*(s.E1*s.E2-s.E0*s.E3))                       // M1/N2
+		jac.Set(12, 15, 2*(s.E1*s.E3+s.E0*s.E2))                       // M1/N3
+		jac.Set(12, 29, 1)                                             // M1/L1
 
-	m.M2 = s.f12*m1 + s.f22*m2 + s.f32*m3 + s.L2
-	jac.Set(13, 6,  2*(+s.E3*s.N1 + s.E0*s.N2 - s.E1*s.N3))        // M2/E0
-	jac.Set(13, 7,  2*(+s.E2*s.N1 - s.E1*s.N2 - s.E0*s.N3))        // M2/E1
-	jac.Set(13, 8,  2*(+s.E1*s.N1 + s.E2*s.N2 + s.E3*s.N3))        // M2/E2
-	jac.Set(13, 9,  2*(+s.E0*s.N1 - s.E3*s.N2 + s.E2*s.N3))        // M2/E3
-	jac.Set(13, 13, 2*(s.E2*s.E1 + s.E0*s.E3))                     // M2/N1
-	jac.Set(13, 14, 2*(s.E2*s.E2 + s.E0*s.E0 - 0.5))               // M2/N2
-	jac.Set(13, 15, 2*(s.E2*s.E3 - s.E0*s.E1))                     // M2/N3
-	jac.Set(13, 30, 1)                                             // M2/L2
+		m.M2 = s.f12*m1 + s.f22*m2 + s.f32*m3 + s.L2
+		jac.Set(13, 6,  2*(+s.E3*s.N1 + s.E0*s.N2 - s.E1*s.N3))        // M2/E0
+		jac.Set(13, 7,  2*(+s.E2*s.N1 - s.E1*s.N2 - s.E0*s.N3))        // M2/E1
+		jac.Set(13, 8,  2*(+s.E1*s.N1 + s.E2*s.N2 + s.E3*s.N3))        // M2/E2
+		jac.Set(13, 9,  2*(+s.E0*s.N1 - s.E3*s.N2 + s.E2*s.N3))        // M2/E3
+		jac.Set(13, 13, 2*(s.E2*s.E1 + s.E0*s.E3))                     // M2/N1
+		jac.Set(13, 14, 2*(s.E2*s.E2 + s.E0*s.E0 - 0.5))               // M2/N2
+		jac.Set(13, 15, 2*(s.E2*s.E3 - s.E0*s.E1))                     // M2/N3
+		jac.Set(13, 30, 1)                                             // M2/L2
 
-	m.M3 = s.f13*m1 + s.f23*m2 + s.f33*m3 + s.L3
-	jac.Set(14, 6,  2*(-s.E2*s.N1 + s.E1*s.N2 + s.E0*s.N3))        // M3/E0
-	jac.Set(14, 7,  2*(+s.E3*s.N1 + s.E0*s.N2 - s.E1*s.N3))        // M3/E1
-	jac.Set(14, 8,  2*(-s.E0*s.N1 + s.E3*s.N2 - s.E2*s.N3))        // M3/E2
-	jac.Set(14, 9,  2*(+s.E1*s.N1 + s.E2*s.N2 + s.E3*s.N3))        // M3/E3
-	jac.Set(14, 13, 2*(s.E3*s.E1 - s.E0*s.E2))                     // M3/N1
-	jac.Set(14, 14, 2*(s.E3*s.E2 + s.E0*s.E1))                     // M3/N2
-	jac.Set(14, 15, 2*(s.E3*s.E3 + s.E0*s.E0 - 0.5))               // M3/N3
-	jac.Set(14, 31, 1)                                             // M3/L3
+		m.M3 = s.f13*m1 + s.f23*m2 + s.f33*m3 + s.L3
+		jac.Set(14, 6,  2*(-s.E2*s.N1 + s.E1*s.N2 + s.E0*s.N3))        // M3/E0
+		jac.Set(14, 7,  2*(+s.E3*s.N1 + s.E0*s.N2 - s.E1*s.N3))        // M3/E1
+		jac.Set(14, 8,  2*(-s.E0*s.N1 + s.E3*s.N2 - s.E2*s.N3))        // M3/E2
+		jac.Set(14, 9,  2*(+s.E1*s.N1 + s.E2*s.N2 + s.E3*s.N3))        // M3/E3
+		jac.Set(14, 13, 2*(s.E3*s.E1 - s.E0*s.E2))                     // M3/N1
+		jac.Set(14, 14, 2*(s.E3*s.E2 + s.E0*s.E1))                     // M3/N2
+		jac.Set(14, 15, 2*(s.E3*s.E3 + s.E0*s.E0 - 0.5))               // M3/N3
+		jac.Set(14, 31, 1)                                             // M3/L3
 	*/
 
 	return

--- a/ahrs/ahrs_test.go
+++ b/ahrs/ahrs_test.go
@@ -1,12 +1,13 @@
 package ahrs
 
 import (
-	"github.com/skelterjohn/go.matrix"
 	"log"
 	"math"
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/skelterjohn/go.matrix"
 )
 
 func createRandomState() (s *KalmanState) {

--- a/ahrs/quaternions_test.go
+++ b/ahrs/quaternions_test.go
@@ -3,10 +3,10 @@ package ahrs
 import (
 	"fmt"
 	"math"
+	"math/rand"
 	"testing"
 
 	"github.com/westphae/quaternion"
-	"math/rand"
 )
 
 var (

--- a/ahrsweb/cmd/ahrsweb_client_random/ahrsweb_client_random.go
+++ b/ahrsweb/cmd/ahrsweb_client_random/ahrsweb_client_random.go
@@ -7,17 +7,17 @@ package main
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
 	"log"
 	"math"
 	"math/rand"
+	"net/url"
 	"os"
+	"os/signal"
 	"time"
 
-	"../../ahrsweb"
-	"fmt"
+	"github.com/cyoung/goflying/ahrsweb"
 	"github.com/gorilla/websocket"
-	"net/url"
-	"os/signal"
 )
 
 func update(data *ahrsweb.AHRSData) {

--- a/ahrsweb/cmd/ahrsweb_server/ahrsweb_server.go
+++ b/ahrsweb/cmd/ahrsweb_server/ahrsweb_server.go
@@ -7,7 +7,6 @@ This book is highly recommended!
 package main
 
 import (
-	"../../../ahrsweb"
 	"flag"
 	"fmt"
 	"html/template"
@@ -15,6 +14,8 @@ import (
 	"net/http"
 	"path/filepath"
 	"sync"
+
+	"github.com/cyoung/goflying/ahrsweb"
 )
 
 // templ represents a single template

--- a/ahrsweb/kalman_listener.go
+++ b/ahrsweb/kalman_listener.go
@@ -5,10 +5,10 @@ import (
 	"log"
 	"time"
 	//"math"
+	"fmt"
 	"net/url"
 
-	"../ahrs"
-	"fmt"
+	"github.com/cyoung/goflying/ahrs"
 	"github.com/gorilla/websocket"
 )
 

--- a/bmp280/bmp280.go
+++ b/bmp280/bmp280.go
@@ -6,13 +6,14 @@ Reference 2: https://forums.adafruit.com/viewtopic.php?f=19&t=89049
 package bmp280
 
 import (
-	"../embd"
-	_ "../embd/host/all"
-	_ "../embd/host/rpi"
 	"fmt"
 	"log"
 	"math"
 	"time"
+
+	"github.com/kidoman/embd"
+	_ "github.com/kidoman/embd/host/all"
+	_ "github.com/kidoman/embd/host/rpi"
 )
 
 const (
@@ -30,7 +31,7 @@ const (
 	SoftResetCode = 0xB6
 	// Standby Time Definitions
 	StandbyTime1ms    = 0x00
-	StandbyTime63ms   = 0X01
+	StandbyTime63ms   = 0x01
 	StandbyTime125ms  = 0x02
 	StandbyTime250ms  = 0x03
 	StandbyTime500ms  = 0x04
@@ -51,10 +52,10 @@ const (
 	Oversamp8x      = 0x04
 	Oversamp16x     = 0x05
 	// Working Mode Definitions
-	UltraLowPowerMode       = 0X00
-	LowPowerMode            = 0X01
-	StandardResolutionMode  = 0X02
-	HighResolutionMode      = 0X03
+	UltraLowPowerMode       = 0x00
+	LowPowerMode            = 0x01
+	StandardResolutionMode  = 0x02
+	HighResolutionMode      = 0x03
 	UltraHighResolutionMode = 0x04
 
 	// BMP280 registers

--- a/bmp280/test/bmp280_test.go
+++ b/bmp280/test/bmp280_test.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"../../bmp280"
-	"../../embd"
 	"fmt"
 	"log"
 	"math"
 	"testing"
+
+	"github.com/cyoung/goflying/bmp280"
+	"github.com/cyoung/goflying/embd"
 )
 
 func TestBMP280Math(t *testing.T) {

--- a/bmp280/test/read_bmp280.go
+++ b/bmp280/test/read_bmp280.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"../../bmp280"
-	"../../embd"
 	"fmt"
 	"time"
+
+	"github.com/cyoung/goflying/bmp280"
+	"github.com/kidoman/embd"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/cyoung/goflying
+
+go 1.14
+
+require (
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
+	github.com/gorilla/websocket v1.4.2
+	github.com/kidoman/embd v0.0.0-20170508013040-d3d8c0c5c68d
+	github.com/skelterjohn/go.matrix v0.0.0-20130517144113-daa59528eefd
+	github.com/westphae/quaternion v0.0.0-20190804192539-eb19a71cb818
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/kidoman/embd v0.0.0-20170508013040-d3d8c0c5c68d h1:dPUSr0RGzXAdsUTMtiyQ/2RBLIIwkv6jGnhxrufitvQ=
+github.com/kidoman/embd v0.0.0-20170508013040-d3d8c0c5c68d/go.mod h1:ACKj9jnzOzj1lw2ETilpFGK7L9dtJhAzT7T1OhAGtRQ=
+github.com/skelterjohn/go.matrix v0.0.0-20130517144113-daa59528eefd h1:+ZLYzP9SYC3WU9buyb9H0l9DQxqVFOCkDG8QnNBMAlA=
+github.com/skelterjohn/go.matrix v0.0.0-20130517144113-daa59528eefd/go.mod h1:x7ui0Rh4QxcWEOgIfa3cr9q4W/wyLTDdzISxBmLVeX8=
+github.com/westphae/quaternion v0.0.0-20190804192539-eb19a71cb818 h1:mqjZgo7sYcdowZ+AKh/pTunpj6dGNA3PzVKo9+WJm3E=
+github.com/westphae/quaternion v0.0.0-20190804192539-eb19a71cb818/go.mod h1:QTAatvZIftK/dJJK1wtxV+M3VF/IW7/nRJukOT52ItQ=

--- a/magnetometer/test/calibration.go
+++ b/magnetometer/test/calibration.go
@@ -6,16 +6,16 @@ import (
 	"net/http"
 	"time"
 
-	"../../mpu9250"
+	"github.com/cyoung/goflying/mpu9250"
 	"github.com/gorilla/websocket"
 )
 
 const numRetries int = 5
 
 var upgrader = websocket.Upgrader{
-	ReadBufferSize: 1024,
+	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
-	CheckOrigin: func(r *http.Request) bool { return true },
+	CheckOrigin:     func(r *http.Request) bool { return true },
 }
 
 func main() {
@@ -48,9 +48,9 @@ func openMPU9250() (mpu *mpu9250.MPU9250, err error) {
 	return mpu, nil
 }
 
-func readData(mpu *mpu9250.MPU9250) (reqData chan chan map[string]interface{}){
+func readData(mpu *mpu9250.MPU9250) (reqData chan chan map[string]interface{}) {
 	var (
-		cur *mpu9250.MPUData
+		cur    *mpu9250.MPUData
 		logMap = make(map[string]interface{})
 	)
 	reqData = make(chan chan map[string]interface{}, 100)
@@ -87,7 +87,7 @@ func sendData(w http.ResponseWriter, r *http.Request, reqData chan chan map[stri
 
 	myData := make(chan map[string]interface{})
 	for {
-		reqData<- myData
+		reqData <- myData
 		err = conn.WriteJSON(<-myData)
 		if err != nil {
 			log.Printf("Error writing to websocket: %s\n", err)
@@ -99,11 +99,15 @@ func sendData(w http.ResponseWriter, r *http.Request, reqData chan chan map[stri
 
 func updateLogMap(t0 time.Time, m *mpu9250.MPUData, p map[string]interface{}) {
 	var sensorLogMap = map[string]func(t0 time.Time, m *mpu9250.MPUData) float64{
-		"T":    func(t0 time.Time, m *mpu9250.MPUData) float64 { return float64(m.T.Sub(t0).Nanoseconds()/1000000) / 1000 },
-		"TM":   func(t0 time.Time, m *mpu9250.MPUData) float64 { return float64(m.TM.Sub(t0).Nanoseconds()/1000000) / 1000 },
-		"M1":   func(t0 time.Time, m *mpu9250.MPUData) float64 { return m.M1 },
-		"M2":   func(t0 time.Time, m *mpu9250.MPUData) float64 { return m.M2 },
-		"M3":   func(t0 time.Time, m *mpu9250.MPUData) float64 { return m.M3 },
+		"T": func(t0 time.Time, m *mpu9250.MPUData) float64 {
+			return float64(m.T.Sub(t0).Nanoseconds()/1000000) / 1000
+		},
+		"TM": func(t0 time.Time, m *mpu9250.MPUData) float64 {
+			return float64(m.TM.Sub(t0).Nanoseconds()/1000000) / 1000
+		},
+		"M1": func(t0 time.Time, m *mpu9250.MPUData) float64 { return m.M1 },
+		"M2": func(t0 time.Time, m *mpu9250.MPUData) float64 { return m.M2 },
+		"M3": func(t0 time.Time, m *mpu9250.MPUData) float64 { return m.M3 },
 	}
 
 	for k := range sensorLogMap {

--- a/mpu9250/dmp_constants.go
+++ b/mpu9250/dmp_constants.go
@@ -1,11 +1,11 @@
 package mpu9250
 
-type IMUChipType int
+type IMUChipVersion int
 
 const (
 	// Supported IMUs.
-	MPU9250 IMUChipType = iota
-	ICM20948
+	IMU_VERSION_MPU9250 IMUChipVersion = iota
+	IMU_VERSION_ICM20948
 
 	// WHO_AM_I values to differentiate between the different IMUs.
 	MPUREG_WHO_AM_I     = 0x75

--- a/mpu9250/mpu9250.go
+++ b/mpu9250/mpu9250.go
@@ -10,9 +10,9 @@ import (
 	"math"
 	"time"
 
-	"../embd"
-	_ "../embd/host/all"
-	_ "../embd/host/rpi"
+	"github.com/kidoman/embd"
+	_ "github.com/kidoman/embd/host/all"
+	_ "github.com/kidoman/embd/host/rpi"
 )
 
 const (

--- a/mpu9250/mpu9250.go
+++ b/mpu9250/mpu9250.go
@@ -48,14 +48,14 @@ type MPU9250 struct {
 	CAvg                  <-chan *MPUData // Average sensor values (since CAvg last read)
 	CBuf                  <-chan *MPUData // Buffer of instantaneous sensor values
 	cClose                chan bool       // Turn off MPU polling
-	chipVersion           IMUChipType
+	chipVersion           IMUChipVersion
 }
 
 /*
 NewMPU9250 creates a new MPU9250 object according to the supplied parameters.  If there is no MPU9250 available or there
 is an error creating the object, an error is returned.
 */
-func NewMPU9250(i2cbus *embd.I2CBus, sensitivityGyro, sensitivityAccel, sampleRate int, enableMag bool, applyHWOffsets bool) (*MPU9250, error) {
+func NewMPU9250(i2cbus embd.I2CBus, sensitivityGyro, sensitivityAccel, sampleRate int, enableMag bool, applyHWOffsets bool) (*MPU9250, error) {
 	var mpu = new(MPU9250)
 
 	mpu.sampleRate = sampleRate
@@ -69,7 +69,7 @@ func NewMPU9250(i2cbus *embd.I2CBus, sensitivityGyro, sensitivityAccel, sampleRa
 	} else {
 		if v == ICMREG_WHO_AM_I_VAL {
 			log.Println("ICM-20948 detected.") //FIXME.
-			mpu.chipVersion = ICM20948
+			mpu.chipVersion = IMU_VERSION_ICM20948
 		}
 	}
 

--- a/mpu9250/test/read_mpu9250.go
+++ b/mpu9250/test/read_mpu9250.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"../../ahrs"
-	"../../mpu9250"
+	"github.com/cyoung/goflying/ahrs"
+	"github.com/cyoung/goflying/mpu9250"
 )
 
 func main() {

--- a/sim/ahrs_sim.go
+++ b/sim/ahrs_sim.go
@@ -16,8 +16,8 @@ import (
 	"strconv"
 	"strings"
 
-	"../ahrs"
 	"encoding/json"
+	"github.com/cyoung/goflying/ahrs"
 )
 
 func parseFloatArrayString(str string, a *[]float64) (err error) {
@@ -121,10 +121,10 @@ func main() {
 
 	switch scenario {
 	/*
-	case "takeoff":
-		sit = sitTakeoffDef
-	case "turn":
-		sit = sitTurnDef
+		case "takeoff":
+			sit = sitTakeoffDef
+		case "turn":
+			sit = sitTurnDef
 	*/
 	default:
 		log.Printf("Loading data from %s\n", scenario)
@@ -140,10 +140,10 @@ func main() {
 	fmt.Println("Simulation parameters:")
 	switch strings.ToLower(algo) {
 	/*
-	case "kalman":
-		fmt.Println("Running Kalman AHRS")
-		ioutil.WriteFile("config.json", []byte(ahrs.KalmanJSONConfig), 0644)
-		s = ahrs.InitializeKalman(m)
+		case "kalman":
+			fmt.Println("Running Kalman AHRS")
+			ioutil.WriteFile("config.json", []byte(ahrs.KalmanJSONConfig), 0644)
+			s = ahrs.InitializeKalman(m)
 	*/
 	case "simple":
 		fallthrough // simple is the default.
@@ -199,7 +199,7 @@ func main() {
 	logMapActual := sit.GetLogMap()
 	var transferLogMap = func() {
 		for k, v := range logMapActual {
-			logMap[k + "Actual"] = v
+			logMap[k+"Actual"] = v
 		}
 	}
 	transferLogMap()

--- a/sim/situation.go
+++ b/sim/situation.go
@@ -1,6 +1,6 @@
 package main
 
-import "../ahrs"
+import "github.com/cyoung/goflying/ahrs"
 
 type Situation interface {
 	BeginTime() float64

--- a/sim/situationFromFile.go
+++ b/sim/situationFromFile.go
@@ -9,29 +9,29 @@ import (
 	"os"
 	"strconv"
 
-	"../ahrs"
+	"github.com/cyoung/goflying/ahrs"
 	"github.com/skelterjohn/go.matrix"
 )
 
 type SituationFromFile struct {
-	ix     int
-	t      []float64
-	a1     []float64
-	a2     []float64
-	a3     []float64
-	h1     []float64
-	h2     []float64
-	h3     []float64
-	m1     []float64
-	m2     []float64
-	m3     []float64
-	tw     []float64
-	w1     []float64
-	w2     []float64
-	w3     []float64
-	wvalid []float64
-	alt    []float64
-	logMap map[string][]*float64 // Map only for analysis/debugging
+	ix            int
+	t             []float64
+	a1            []float64
+	a2            []float64
+	a3            []float64
+	h1            []float64
+	h2            []float64
+	h3            []float64
+	m1            []float64
+	m2            []float64
+	m3            []float64
+	tw            []float64
+	w1            []float64
+	w2            []float64
+	w3            []float64
+	wvalid        []float64
+	alt           []float64
+	logMap        map[string][]*float64 // Map only for analysis/debugging
 	logMapCurrent map[string]interface{}
 }
 
@@ -73,8 +73,8 @@ func NewSituationFromFile(fn string) (sit *SituationFromFile, err error) {
 
 	// Read the rest of the data into the situation
 	var (
-		j   int
-		t0  float64
+		j  int
+		t0 float64
 	)
 	for {
 		rec, err = r.Read()
@@ -172,9 +172,9 @@ func (s *SituationFromFile) UpdateState(st *ahrs.State, aBias, bBias, mBias []fl
 }
 
 func (s *SituationFromFile) UpdateMeasurement(m *ahrs.Measurement,
-		uValid, wValid, sValid, mValid bool,
-		uNoise, wNoise, aNoise, bNoise, mNoise float64,
-		uBias, aBias, bBias, mBias []float64) error {
+	uValid, wValid, sValid, mValid bool,
+	uNoise, wNoise, aNoise, bNoise, mNoise float64,
+	uBias, aBias, bBias, mBias []float64) error {
 	m.U1 = 0
 	m.U2 = 0
 	m.U3 = 0

--- a/sim/situationSim.go
+++ b/sim/situationSim.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"../ahrs"
 	"errors"
-	"github.com/skelterjohn/go.matrix"
 	"math"
 	"math/rand"
 	"sort"
+
+	"github.com/cyoung/goflying/ahrs"
+	"github.com/skelterjohn/go.matrix"
 )
 
 const (
@@ -19,12 +20,12 @@ var TimeError = errors.New("requested time is outside of scenario")
 
 // Situation defines a scenario by piecewise-linear interpolation
 type SituationSim struct {
-	t                  []float64 // times for situation, s
-	u1, u2, u3         []float64 // airspeed, kts, aircraft frame [F/B, R/L, and U/D]
-	phi, theta, psi    []float64 // attitude, rad [roll R/L, pitch U/D, heading N->E->S->W]
-	phi0, theta0, psi0 []float64 // base attitude, rad [adjust for position of stratux on glareshield]
-	v1, v2, v3         []float64 // windspeed, kts, earth frame [N/S, E/W, and U/D]
-	m1, m2, m3         []float64 // magnetometer reading
+	t                  []float64              // times for situation, s
+	u1, u2, u3         []float64              // airspeed, kts, aircraft frame [F/B, R/L, and U/D]
+	phi, theta, psi    []float64              // attitude, rad [roll R/L, pitch U/D, heading N->E->S->W]
+	phi0, theta0, psi0 []float64              // base attitude, rad [adjust for position of stratux on glareshield]
+	v1, v2, v3         []float64              // windspeed, kts, earth frame [N/S, E/W, and U/D]
+	m1, m2, m3         []float64              // magnetometer reading
 	logMap             map[string]interface{} // Map only for analysis/debugging
 }
 


### PR DESCRIPTION
This PR both adds versioning with Go modules and fixes an error which arose from a naming conflict between the `MPU9250` constant and `MPU9250` struct. 